### PR TITLE
feat(text-ellipsis): add new component & add support to badge

### DIFF
--- a/apps/docs/stories/badge.stories.tsx
+++ b/apps/docs/stories/badge.stories.tsx
@@ -544,6 +544,111 @@ export const CapitalizedText: Story = {
 	),
 };
 
+export const TextEllipsisPositions: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The `textEllipsis` prop enables canvas-based text truncation with ellipsis at different positions. Use `true` or `"center"` for center truncation (default), `"start"` for start truncation, or `"end"` for end truncation. Only works with string children.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		color: { control: false },
+		variant: { control: false },
+		capitalize: { control: false },
+		asChild: { control: false },
+		textEllipsis: { control: false },
+	},
+	render: () => (
+		<div className="space-y-6">
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					Ellipsis Positions
+				</h3>
+				<div className="flex flex-col gap-3">
+					<div className="flex items-center gap-3">
+						<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-16">Center:</span>
+						<div style={{ '--badge-width': '180px' } as React.CSSProperties}>
+							<Badge color="robin" textEllipsis="center">
+								This is a very long badge text that will be truncated in the center
+							</Badge>
+						</div>
+					</div>
+					<div className="flex items-center gap-3">
+						<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-16">Start:</span>
+						<div style={{ '--badge-width': '180px' } as React.CSSProperties}>
+							<Badge color="forest" textEllipsis="start">
+								path/to/very/long/filename/that/needs/truncation.tsx
+							</Badge>
+						</div>
+					</div>
+					<div className="flex items-center gap-3">
+						<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-16">End:</span>
+						<div style={{ '--badge-width': '180px' } as React.CSSProperties}>
+							<Badge color="amber" textEllipsis="end">
+								A long description that should be truncated at the end
+							</Badge>
+						</div>
+					</div>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					Boolean Shorthand (defaults to center)
+				</h3>
+				<div className="flex flex-col gap-2">
+					<div style={{ '--badge-width': '200px' } as React.CSSProperties}>
+						<Badge color="aqua" textEllipsis>
+							Using textEllipsis=true defaults to center truncation
+						</Badge>
+					</div>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					With Outline Variant
+				</h3>
+				<div className="flex flex-col gap-2">
+					<div style={{ '--badge-width': '160px' } as React.CSSProperties}>
+						<Badge color="cherry" variant="outline" textEllipsis="center">
+							Error: Connection timeout after 30 seconds of inactivity
+						</Badge>
+					</div>
+					<div style={{ '--badge-width': '160px' } as React.CSSProperties}>
+						<Badge color="sakura" variant="outline" textEllipsis="end">
+							User: very.long.email.address@example.domain.com
+						</Badge>
+					</div>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					Container Constrained
+				</h3>
+				<p className="text-xs text-vanilla-600 dark:text-vanilla-300 mb-2">
+					Badges inside a narrow container will truncate automatically with textEllipsis
+				</p>
+				<div
+					className="flex flex-col gap-2 p-2 border border-vanilla-300 dark:border-vanilla-700 rounded"
+					style={{ width: '220px', '--badge-width': '100%' } as React.CSSProperties}
+				>
+					<Badge color="robin" textEllipsis="center">
+						kubernetes-deployment-production-east-us-2
+					</Badge>
+					<Badge color="forest" variant="outline" textEllipsis="start">
+						/var/log/application/server/debug/2024-01-15.log
+					</Badge>
+					<Badge color="sienna" textEllipsis="end">
+						Successfully processed 1,234 items in batch
+					</Badge>
+				</div>
+			</div>
+		</div>
+	),
+};
+
 export const UsingAsChild: Story = {
 	parameters: {
 		docs: {

--- a/apps/docs/stories/text-ellipsis.stories.tsx
+++ b/apps/docs/stories/text-ellipsis.stories.tsx
@@ -1,0 +1,338 @@
+import { TextEllipsis, useTextEllipsisWidth } from '@signozhq/ui';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof TextEllipsis> = {
+	title: 'Components/TextEllipsis',
+	component: TextEllipsis,
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'A text component that truncates content with ellipsis at start, center, or end position. Uses canvas-based text measurement for accurate truncation without DOM reflows. Supports ResizeObserver for responsive containers.',
+			},
+		},
+	},
+	argTypes: {
+		children: {
+			control: 'text',
+			description: 'The text content to display with ellipsis truncation.',
+			table: { category: 'Content' },
+		},
+		position: {
+			control: 'inline-radio',
+			options: ['start', 'center', 'end'],
+			description: 'Where to place the ellipsis when text overflows.',
+			table: { category: 'Behavior', defaultValue: { summary: 'center' } },
+		},
+		ellipsis: {
+			control: 'text',
+			description: 'The ellipsis string to use.',
+			table: { category: 'Behavior', defaultValue: { summary: '...' } },
+		},
+		width: {
+			control: 'number',
+			description:
+				'The width of the container in pixels. If not provided, the component measures its own width.',
+			table: { category: 'Layout' },
+		},
+		className: {
+			control: 'text',
+			description: 'Optional className for the container.',
+			table: { category: 'Appearance' },
+		},
+		title: {
+			control: 'text',
+			description: 'Optional title attribute. Defaults to the full text when truncated.',
+			table: { category: 'Accessibility' },
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextEllipsis>;
+
+export const Playground: Story = {
+	args: {
+		children: 'This is a very long text that will be truncated based on the container width',
+		position: 'center',
+		ellipsis: '...',
+	},
+	render: (props) => (
+		<div style={{ width: '300px', padding: '16px' }}>
+			<TextEllipsis {...props} />
+		</div>
+	),
+};
+
+export const EllipsisPositions: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The three truncation positions: `center` keeps both the start and end visible, `start` preserves the end (great for file paths), and `end` preserves the start (classic truncation behavior).',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<div className="flex items-center gap-3">
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-12 shrink-0">
+					Center:
+				</span>
+				<div style={{ width: '240px' }}>
+					<TextEllipsis position="center">
+						This is a very long text that will be truncated in the center
+					</TextEllipsis>
+				</div>
+			</div>
+			<div className="flex items-center gap-3">
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-12 shrink-0">Start:</span>
+				<div style={{ width: '240px' }}>
+					<TextEllipsis position="start">
+						path/to/very/long/filename/that/needs/truncation.tsx
+					</TextEllipsis>
+				</div>
+			</div>
+			<div className="flex items-center gap-3">
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300 w-12 shrink-0">End:</span>
+				<div style={{ width: '240px' }}>
+					<TextEllipsis position="end">
+						A long description that should be truncated at the end of the text
+					</TextEllipsis>
+				</div>
+			</div>
+		</div>
+	),
+};
+
+export const FilePaths: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Use `position="start"` to truncate file paths from the beginning, keeping the filename visible. Use `position="center"` to show both the root and the filename.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					Start Truncation (shows filename)
+				</h3>
+				<div className="flex flex-col gap-2" style={{ width: '280px' }}>
+					<TextEllipsis position="start">
+						/var/log/application/server/debug/2024-01-15.log
+					</TextEllipsis>
+					<TextEllipsis position="start">
+						/home/user/projects/my-app/src/components/Button/index.tsx
+					</TextEllipsis>
+					<TextEllipsis position="start">
+						C:\Users\John\Documents\Projects\MyApp\src\utils\helpers.ts
+					</TextEllipsis>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-2 text-vanilla-800 dark:text-vanilla-300">
+					Center Truncation (shows root and filename)
+				</h3>
+				<div className="flex flex-col gap-2" style={{ width: '280px' }}>
+					<TextEllipsis position="center">
+						/var/log/application/server/debug/2024-01-15.log
+					</TextEllipsis>
+					<TextEllipsis position="center">
+						/home/user/projects/my-app/src/components/Button/index.tsx
+					</TextEllipsis>
+				</div>
+			</div>
+		</div>
+	),
+};
+
+export const CustomEllipsis: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The `ellipsis` prop lets you customize the truncation indicator. Use any string: a single character, Unicode symbol, or longer phrase.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+	},
+	render: () => (
+		<div className="space-y-3 p-4" style={{ width: '280px' }}>
+			<div>
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300">Default (...)</span>
+				<TextEllipsis ellipsis="...">
+					This is a very long text that will be truncated with default ellipsis
+				</TextEllipsis>
+			</div>
+			<div>
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300">Unicode (…)</span>
+				<TextEllipsis ellipsis="…">
+					This is a very long text that will be truncated with unicode ellipsis
+				</TextEllipsis>
+			</div>
+			<div>
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300">Tilde (~)</span>
+				<TextEllipsis ellipsis="~" position="start">
+					/home/user/projects/my-app/src/components/Button/index.tsx
+				</TextEllipsis>
+			</div>
+			<div>
+				<span className="text-xs text-vanilla-600 dark:text-vanilla-300">More (›)</span>
+				<TextEllipsis ellipsis=" ›" position="end">
+					Read more about this very long topic with lots of details
+				</TextEllipsis>
+			</div>
+		</div>
+	),
+};
+
+export const ResponsiveContainer: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'When no `width` prop is provided, `TextEllipsis` measures its own container width using ResizeObserver. It will re-truncate automatically when the container resizes.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<p className="text-xs text-vanilla-600 dark:text-vanilla-300">
+				Resize the browser window to see the text adapt automatically.
+			</p>
+			<div
+				className="flex flex-col gap-2 p-3 border border-vanilla-300 dark:border-vanilla-700 rounded"
+				style={{ width: '100%', maxWidth: '400px' }}
+			>
+				<TextEllipsis position="center">
+					kubernetes-deployment-production-east-us-2-replica-set
+				</TextEllipsis>
+				<TextEllipsis position="start">
+					/var/log/application/server/debug/2024-01-15.log
+				</TextEllipsis>
+				<TextEllipsis position="end">
+					Successfully processed 1,234 items in the background batch job
+				</TextEllipsis>
+			</div>
+		</div>
+	),
+};
+
+export const WithExternalWidth: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Use the `width` prop to control truncation externally. Pair with the `useTextEllipsisWidth` hook to measure a parent container and pass the width down — useful when `TextEllipsis` is used inside complex layout components.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+	},
+	render: () => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
+		const { ref, width } = useTextEllipsisWidth<HTMLDivElement>();
+
+		return (
+			<div className="space-y-4 p-4">
+				<p className="text-xs text-vanilla-600 dark:text-vanilla-300">
+					Using <code>useTextEllipsisWidth</code> hook to measure the container and pass width
+					externally. Current width: {width}px
+				</p>
+				<div
+					ref={ref as any}
+					className="p-3 border border-vanilla-300 dark:border-vanilla-700 rounded"
+					style={{ width: '320px' }}
+				>
+					<TextEllipsis position="center" width={width}>
+						kubernetes-deployment-production-east-us-2
+					</TextEllipsis>
+				</div>
+			</div>
+		);
+	},
+};
+
+export const TooltipOnTruncation: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'When text is truncated, the full text is automatically set as the `title` attribute, giving users a native tooltip on hover. You can override this with a custom `title` prop.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		position: { control: false },
+		ellipsis: { control: false },
+		width: { control: false },
+		title: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<p className="text-xs text-vanilla-600 dark:text-vanilla-300">
+				Hover over the truncated text to see the full content as a tooltip.
+			</p>
+			<div className="flex flex-col gap-2" style={{ width: '240px' }}>
+				<div>
+					<span className="text-xs text-vanilla-600 dark:text-vanilla-300 block mb-1">
+						Auto title (full text):
+					</span>
+					<TextEllipsis position="center">
+						This is a very long text that will be truncated — hover to see all
+					</TextEllipsis>
+				</div>
+				<div>
+					<span className="text-xs text-vanilla-600 dark:text-vanilla-300 block mb-1">
+						Custom title override:
+					</span>
+					<TextEllipsis
+						position="end"
+						title="Custom tooltip: /home/user/projects/my-app/src/components/Button/index.tsx"
+					>
+						/home/user/projects/my-app/src/components/Button/index.tsx
+					</TextEllipsis>
+				</div>
+				<div>
+					<span className="text-xs text-vanilla-600 dark:text-vanilla-300 block mb-1">
+						Short text (no tooltip):
+					</span>
+					<TextEllipsis position="center">Short text</TextEllipsis>
+				</div>
+			</div>
+		</div>
+	),
+};

--- a/package.json
+++ b/package.json
@@ -123,6 +123,9 @@
 					"vite": "npm:rolldown-vite@7.3.1"
 				}
 			}
+		},
+		"patchedDependencies": {
+			"rolldown-vite@7.3.1": "patches/rolldown-vite@7.3.1.patch"
 		}
 	},
 	"version": "0.0.7"

--- a/packages/typescript-config/vite.config.extend.ts
+++ b/packages/typescript-config/vite.config.extend.ts
@@ -27,6 +27,7 @@ export const externalPatterns = [
 	'@tanstack/react-table',
 	/@radix-ui\/.*$/,
 	/^@signozhq\/.*$/,
+	'@chenglou/pretext',
 ];
 
 export default function getViteLibConfig(

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -45,6 +45,7 @@
 		"vitest": "^4.0.18"
 	},
 	"dependencies": {
+		"@chenglou/pretext": "^0.0.4",
 		"@radix-ui/react-checkbox": "^1.2.3",
 		"@radix-ui/react-dialog": "^1.1.11",
 		"@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/packages/ui/src/badge/badge.module.css
+++ b/packages/ui/src/badge/badge.module.css
@@ -1,25 +1,28 @@
 .badge {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+    display: var(--badge-display, inline-flex);
+    align-items: var(--badge-align-items, center);
+    justify-content: var(--badge-justify-content, center);
     border-radius: var(--badge-border-radius, var(--radius-round, 9999px));
     border: var(--badge-border-width, 1px) solid var(--badge-border-color, transparent);
     padding: var(--badge-padding, var(--spacing-2, 0.25rem) var(--spacing-4, 0.5rem));
     font-size: var(--badge-font-size, var(--periscope-font-size-small, 11px));
     line-height: var(--badge-line-height, 100%);
     font-weight: var(--badge-font-weight, var(--font-weight-medium));
-    width: fit-content;
-    white-space: nowrap;
-    flex-shrink: 0;
+    width: var(--badge-width, fit-content);
+    white-space: var(--badge-white-space, nowrap);
     gap: var(--badge-gap, var(--spacing-2, 0.25rem));
-    overflow: hidden;
+    overflow: var(--badge-overflow, hidden);
     background-color: var(--badge-background);
     color: var(--badge-foreground);
-    cursor: default;
-    transition-property: color, box-shadow;
-    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-    transition-duration: 150ms;
-    font-variant-numeric: slashed-zero;
+    cursor: var(--badge-cursor, default);
+    transition-property: var(--badge-transition-property, color, box-shadow);
+    transition-timing-function: var(--badge-transition-timing-function, cubic-bezier(0.4, 0, 0.2, 1));
+    transition-duration: var(--badge-transition-duration, 150ms);
+    font-variant-numeric: var(--badge-font-variant-numeric, slashed-zero);
+
+    & > * {
+        display: var(--badge-child-display, block);
+    }
 
     &[data-color="vanilla"] {
         --badge-background: var(--bg-neutral-light-950);
@@ -162,4 +165,14 @@
 
 .badge[data-capitalize="false"] {
     font-weight: var(--badge-capitalize-font-weight, var(--font-weight-normal));
+}
+
+.badge[data-text-ellipsis="true"] {
+    display: flex;
+    min-width: 0;
+}
+
+.badgeEllipsis {
+    flex: 1;
+    min-width: 0;
 }

--- a/packages/ui/src/badge/badge.tsx
+++ b/packages/ui/src/badge/badge.tsx
@@ -1,6 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
 import type React from 'react';
 import { cn } from '../lib/utils.js';
+import { TextEllipsis, type TextEllipsisProps } from '../text-ellipsis/index.js';
 import styles from './badge.module.css';
 
 type BadgeVariant = 'default' | 'outline';
@@ -19,6 +20,8 @@ type BadgeColor =
 	| 'sakura'
 	| 'aqua'
 	| 'vanilla';
+
+type TextEllipsisPosition = TextEllipsisProps['position'];
 
 interface BadgeProps
 	extends Pick<React.ComponentProps<'span'>, 'className' | 'children' | 'id' | 'style'> {
@@ -42,6 +45,13 @@ interface BadgeProps
 	 * @default false
 	 */
 	capitalize?: boolean;
+	/**
+	 * Enable text ellipsis truncation. When true, uses 'center' position.
+	 * When a position is provided ('start' | 'center' | 'end'), truncates at that position.
+	 * Only works when children is a string. For non-string children, use CSS text-overflow instead.
+	 * @default false
+	 */
+	textEllipsis?: boolean | TextEllipsisPosition;
 }
 
 const colorMap: Record<string, string> = {
@@ -59,9 +69,33 @@ function Badge({
 	asChild = false,
 	capitalize = false,
 	testId,
+	textEllipsis = false,
+	children,
 	...props
 }: BadgeProps) {
 	const Comp = asChild ? Slot : 'span';
+
+	// Determine ellipsis position
+	const ellipsisPosition: TextEllipsisPosition | false =
+		textEllipsis === true ? 'center' : textEllipsis === false ? false : textEllipsis;
+
+	// Check if we should apply text ellipsis
+	const shouldApplyEllipsis = ellipsisPosition && typeof children === 'string';
+
+	// Warn if textEllipsis is used with non-string children
+	if (ellipsisPosition && typeof children !== 'string') {
+		console.warn(
+			'Badge: textEllipsis only works when children is a string. For non-string children, use CSS text-overflow (textWrap) instead.'
+		);
+	}
+
+	const content = shouldApplyEllipsis ? (
+		<TextEllipsis position={ellipsisPosition} className={styles.badgeEllipsis}>
+			{children}
+		</TextEllipsis>
+	) : (
+		children
+	);
 
 	return (
 		<Comp
@@ -70,9 +104,12 @@ function Badge({
 			data-capitalize={capitalize}
 			data-slot="badge"
 			data-testid={testId}
+			data-text-ellipsis={shouldApplyEllipsis || undefined}
 			className={cn(styles.badge, className)}
 			{...props}
-		/>
+		>
+			{content}
+		</Comp>
 	);
 }
 

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -22,6 +22,7 @@ export * from './sonner/index.js';
 export * from './switch/index.js';
 export * from './table/index.js';
 export * from './tabs/index.js';
+export * from './text-ellipsis/index.js';
 export * from './toggle/index.js';
 export * from './toggle-group/index.js';
 export * from './tooltip/index.js';

--- a/packages/ui/src/text-ellipsis/index.ts
+++ b/packages/ui/src/text-ellipsis/index.ts
@@ -1,0 +1,2 @@
+export type * from './text-ellipsis.js';
+export { TextEllipsis, useTextEllipsisWidth } from './text-ellipsis.js';

--- a/packages/ui/src/text-ellipsis/text-ellipsis.module.css
+++ b/packages/ui/src/text-ellipsis/text-ellipsis.module.css
@@ -1,0 +1,6 @@
+.textEllipsis {
+    display: block;
+    width: 100%;
+    overflow: hidden;
+    white-space: nowrap;
+}

--- a/packages/ui/src/text-ellipsis/text-ellipsis.tsx
+++ b/packages/ui/src/text-ellipsis/text-ellipsis.tsx
@@ -1,0 +1,401 @@
+import {
+	type LayoutCursor,
+	type LayoutLineRange,
+	layoutNextLine,
+	type PreparedTextWithSegments,
+	prepareWithSegments,
+	walkLineRanges,
+} from '@chenglou/pretext';
+import { type RefObject, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { cn } from '../lib/utils.js';
+import styles from './text-ellipsis.module.css';
+
+type TextEllipsisPosition = 'start' | 'center' | 'end';
+
+export interface TextEllipsisProps {
+	/**
+	 * The text content to display with ellipsis truncation.
+	 */
+	children: string;
+	/**
+	 * Where to place the ellipsis when text overflows.
+	 * @default 'center'
+	 */
+	position?: TextEllipsisPosition;
+	/**
+	 * The ellipsis string to use.
+	 * @default '...'
+	 */
+	ellipsis?: string;
+	/**
+	 * The width of the container. If not provided, the component will measure its own width.
+	 * Use this when you need to control the width externally (e.g., when combining with other components).
+	 */
+	width?: number;
+	/**
+	 * Optional className for the container.
+	 */
+	className?: string;
+	/**
+	 * Optional title attribute. If not provided, the full text will be used as title when truncated.
+	 */
+	title?: string;
+}
+
+const START_CURSOR: LayoutCursor = { segmentIndex: 0, graphemeIndex: 0 };
+const LARGE_WIDTH = Number.MAX_SAFE_INTEGER;
+
+function getComputedFont(element: HTMLElement): string {
+	const style = getComputedStyle(element);
+	// Build a minimal valid canvas ctx.font string manually.
+	// We cannot use style.font directly — it can include non-shorthand font
+	// properties (e.g. font-variant-numeric: "slashed-zero" from badge CSS)
+	// that are invalid in the CSS font shorthand syntax accepted by canvas,
+	// causing canvas to silently reject the whole string and fall back to
+	// "10px sans-serif", producing completely wrong measurements.
+	// Only fontStyle, fontWeight, fontSize, fontFamily are safe to include.
+	return `${style.fontStyle} ${style.fontWeight} ${style.fontSize} ${style.fontFamily}`;
+}
+
+/**
+ * Measures the natural (unwrapped) width of prepared text.
+ */
+function measureNaturalWidth(prepared: PreparedTextWithSegments): number {
+	let width = 0;
+	walkLineRanges(prepared, LARGE_WIDTH, (line: LayoutLineRange) => {
+		width = line.width;
+	});
+	return width;
+}
+
+/**
+ * Returns true if the text fits on a single line within maxWidth.
+ */
+function fitsInSingleLine(prepared: PreparedTextWithSegments, maxWidth: number): boolean {
+	const line = layoutNextLine(prepared, START_CURSOR, maxWidth);
+	if (line === null) return true;
+	return layoutNextLine(prepared, line.end, maxWidth) === null;
+}
+
+/**
+ * Finds the longest suffix of text that fits within maxWidth.
+ * Unlike getLastLine which uses line-breaking (may leave space unused),
+ * this directly measures substrings from the end to maximize content.
+ */
+function getMaxSuffix(text: string, maxWidth: number, font: string): string {
+	if (!text) return '';
+
+	// Use floor for available width to be conservative
+	const availableWidth = Math.floor(maxWidth);
+
+	// Check if full text fits
+	const fullPrepared = prepareWithSegments(text, font);
+	const fullWidth = Math.ceil(measureNaturalWidth(fullPrepared));
+	if (fullWidth <= availableWidth) {
+		return text;
+	}
+
+	// Collect all possible start positions (word boundaries + character positions)
+	const startPositions: number[] = [];
+
+	// Add word boundary positions (after each whitespace sequence)
+	for (const match of text.matchAll(/\s+/g)) {
+		const afterSpace = (match.index ?? 0) + match[0].length;
+		if (afterSpace < text.length) {
+			startPositions.push(afterSpace);
+		}
+	}
+
+	// If no word boundaries, add character positions
+	if (startPositions.length === 0) {
+		for (let i = 1; i < text.length; i++) {
+			startPositions.push(i);
+		}
+	}
+
+	// Sort positions (should already be sorted, but ensure it)
+	startPositions.sort((a, b) => a - b);
+
+	// Binary search: find the earliest start position where suffix fits
+	let left = 0;
+	let right = startPositions.length - 1;
+	let bestStart = text.length; // Default to empty suffix
+
+	while (left <= right) {
+		const mid = Math.floor((left + right) / 2);
+		const startIdx = startPositions[mid];
+		const suffix = text.slice(startIdx);
+		const suffixPrepared = prepareWithSegments(suffix, font);
+		// Use ceil for measured width to be conservative
+		const suffixWidth = Math.ceil(measureNaturalWidth(suffixPrepared));
+
+		if (suffixWidth <= availableWidth) {
+			bestStart = startIdx;
+			right = mid - 1; // Try earlier start (more text)
+		} else {
+			left = mid + 1; // Try later start (less text)
+		}
+	}
+
+	return text.slice(bestStart);
+}
+
+function truncateText(
+	text: string,
+	maxWidth: number,
+	font: string,
+	position: TextEllipsisPosition,
+	ellipsis: string
+): { truncated: string; isTruncated: boolean } {
+	if (!text) {
+		return { truncated: text, isTruncated: false };
+	}
+
+	const prepared = prepareWithSegments(text, font);
+
+	if (fitsInSingleLine(prepared, maxWidth)) {
+		return { truncated: text, isTruncated: false };
+	}
+
+	const ellipsisPrepared = prepareWithSegments(ellipsis, font);
+	const ellipsisWidth = Math.ceil(measureNaturalWidth(ellipsisPrepared));
+
+	if (ellipsisWidth >= maxWidth) {
+		return { truncated: ellipsis, isTruncated: true };
+	}
+
+	// Use floor and subtract safety margin for canvas vs browser rendering differences
+	const targetWidth = Math.floor(maxWidth - ellipsisWidth) - 2;
+
+	if (position === 'end') {
+		// layoutNextLine at targetWidth gives the maximum prefix at grapheme granularity
+		// (word boundaries first, then grapheme boundaries via overflow-wrap: break-word)
+		const line = layoutNextLine(prepared, START_CURSOR, targetWidth);
+		if (line === null) {
+			return { truncated: ellipsis, isTruncated: true };
+		}
+		return { truncated: line.text.trimEnd() + ellipsis, isTruncated: true };
+	}
+
+	if (position === 'start') {
+		// Find the longest suffix that fits
+		const suffix = getMaxSuffix(text, targetWidth, font);
+		if (!suffix) {
+			return { truncated: ellipsis, isTruncated: true };
+		}
+		return { truncated: ellipsis + suffix, isTruncated: true };
+	}
+
+	// center: smart split maximizing visible content without overlap
+	// Strategy: try different cut points and pick the one showing most characters
+	// Cut points are at word boundaries when possible, falling back to character positions
+
+	// Find all potential cut points (word boundaries + some character positions)
+	const cutPoints: number[] = [];
+
+	// Add word boundary positions
+	let pos = 0;
+	for (const match of text.matchAll(/\s+/g)) {
+		// Position after the word (before whitespace)
+		if (match.index !== undefined && match.index > 0) {
+			cutPoints.push(match.index);
+		}
+		// Position after whitespace (start of next word)
+		pos = (match.index ?? 0) + match[0].length;
+		if (pos < text.length) {
+			cutPoints.push(pos);
+		}
+	}
+
+	// If no word boundaries (single word), add character positions at intervals
+	if (cutPoints.length === 0) {
+		const step = Math.max(1, Math.floor(text.length / 10));
+		for (let i = step; i < text.length; i += step) {
+			cutPoints.push(i);
+		}
+	}
+
+	// Ensure we try positions near the middle too
+	const mid = Math.floor(text.length / 2);
+	if (!cutPoints.includes(mid)) {
+		cutPoints.push(mid);
+	}
+
+	// Sort and dedupe
+	const uniqueCutPoints = [...new Set(cutPoints)].sort((a, b) => a - b);
+
+	let bestResult = { prefix: '', suffix: '', totalLength: 0, wastedSpace: Infinity };
+
+	for (const cutPoint of uniqueCutPoints) {
+		const prefixText = text.slice(0, cutPoint).trimEnd();
+		const suffixText = text.slice(cutPoint).trimStart();
+
+		if (!prefixText || !suffixText) continue;
+
+		const prefixPrepared = prepareWithSegments(prefixText, font);
+
+		// Get what fits from prefix (from start)
+		const prefixLine = layoutNextLine(prefixPrepared, START_CURSOR, targetWidth);
+		const shownPrefix = prefixLine?.text.trimEnd() ?? '';
+		// Use ceil for measured widths to be conservative
+		const prefixWidth = Math.ceil(measureNaturalWidth(prepareWithSegments(shownPrefix, font)));
+
+		// Use floor for remaining width to be conservative
+		const remainingWidth = Math.floor(targetWidth - prefixWidth);
+		if (remainingWidth <= 0) continue;
+
+		const shownSuffix = getMaxSuffix(suffixText, remainingWidth, font);
+		const suffixWidth = Math.ceil(measureNaturalWidth(prepareWithSegments(shownSuffix, font)));
+
+		if (prefixWidth + suffixWidth > targetWidth) continue;
+
+		const totalLength = shownPrefix.length + shownSuffix.length;
+		const wastedSpace = targetWidth - prefixWidth - suffixWidth;
+
+		// Prefer more content, then less wasted space
+		if (
+			totalLength > bestResult.totalLength ||
+			(totalLength === bestResult.totalLength && wastedSpace < bestResult.wastedSpace)
+		) {
+			bestResult = { prefix: shownPrefix, suffix: shownSuffix, totalLength, wastedSpace };
+		}
+	}
+
+	// Fallback if no good cut point found
+	if (bestResult.totalLength === 0) {
+		const halfWidth = Math.floor(targetWidth / 2);
+		const prefixLine = layoutNextLine(prepared, START_CURSOR, halfWidth);
+		const prefix = prefixLine?.text.trimEnd() ?? '';
+		const prefixWidth = Math.ceil(measureNaturalWidth(prepareWithSegments(prefix, font)));
+		const remainingText = text.slice(prefix.length).trimStart();
+		const suffix = getMaxSuffix(remainingText, Math.floor(targetWidth - prefixWidth), font);
+		return { truncated: prefix + ellipsis + suffix, isTruncated: true };
+	}
+
+	return {
+		truncated: bestResult.prefix + ellipsis + bestResult.suffix,
+		isTruncated: true,
+	};
+}
+
+/**
+ * Hook to track element width using ResizeObserver.
+ * More performant than MutationObserver for size changes.
+ *
+ * @example
+ * ```tsx
+ * const { ref, width } = useTextEllipsisWidth();
+ *
+ * return (
+ *   <div ref={ref} style={{ width: '100%' }}>
+ *     <TextEllipsis width={width}>Long text here</TextEllipsis>
+ *   </div>
+ * );
+ * ```
+ */
+export function useTextEllipsisWidth<T extends HTMLElement = HTMLElement>(): {
+	ref: RefObject<T | null>;
+	width: number;
+} {
+	const ref = useRef<T>(null);
+	const [width, setWidth] = useState(0);
+
+	useLayoutEffect(() => {
+		const element = ref.current;
+		if (!element) return;
+
+		setWidth(element.clientWidth);
+
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				if (entry.contentBoxSize) {
+					const contentBoxSize = Array.isArray(entry.contentBoxSize)
+						? entry.contentBoxSize[0]
+						: entry.contentBoxSize;
+					setWidth(contentBoxSize.inlineSize);
+				} else {
+					setWidth(entry.contentRect.width);
+				}
+			}
+		});
+
+		observer.observe(element);
+
+		return () => observer.disconnect();
+	}, []);
+
+	return { ref, width };
+}
+
+/**
+ * A text component that truncates content with ellipsis at start, center, or end.
+ * Uses pretext for accurate text measurement without DOM reflows.
+ *
+ * @example
+ * ```tsx
+ * <TextEllipsis>This is a very long text that will be truncated</TextEllipsis>
+ * <TextEllipsis position="start">path/to/very/long/filename.txt</TextEllipsis>
+ * <TextEllipsis position="end">A long description here</TextEllipsis>
+ * ```
+ */
+export function TextEllipsis({
+	children,
+	position = 'center',
+	ellipsis = '...',
+	width: externalWidth,
+	className,
+	title,
+}: TextEllipsisProps) {
+	const containerRef = useRef<HTMLSpanElement>(null);
+	const [internalWidth, setInternalWidth] = useState(0);
+	const [font, setFont] = useState('');
+
+	const width = externalWidth ?? internalWidth;
+
+	useLayoutEffect(() => {
+		const element = containerRef.current;
+		if (!element) return;
+
+		setFont(getComputedFont(element));
+
+		if (externalWidth !== undefined) return;
+
+		setInternalWidth(element.clientWidth);
+
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				if (entry.contentBoxSize) {
+					const contentBoxSize = Array.isArray(entry.contentBoxSize)
+						? entry.contentBoxSize[0]
+						: entry.contentBoxSize;
+					setInternalWidth(contentBoxSize.inlineSize);
+				} else {
+					setInternalWidth(entry.contentRect.width);
+				}
+			}
+		});
+
+		observer.observe(element);
+
+		return () => observer.disconnect();
+	}, [externalWidth]);
+
+	const { truncated, isTruncated } = useMemo(() => {
+		if (!font || width <= 0) {
+			return { truncated: children, isTruncated: false };
+		}
+
+		return truncateText(children, Math.floor(width), font, position, ellipsis);
+	}, [children, width, font, position, ellipsis]);
+
+	return (
+		<span
+			ref={containerRef}
+			className={cn(styles.textEllipsis, className)}
+			title={isTruncated ? (title ?? children) : title}
+			data-truncated={isTruncated}
+		>
+			{truncated}
+		</span>
+	);
+}

--- a/patches/rolldown-vite@7.3.1.patch
+++ b/patches/rolldown-vite@7.3.1.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/node/chunks/node.js b/dist/node/chunks/node.js
+index 21f8d7cf6b0c9e9f473b891b9b1de0d7f857179b..f741e932683223b834b0c90659271c15e7d63147 100644
+--- a/dist/node/chunks/node.js
++++ b/dist/node/chunks/node.js
+@@ -14754,8 +14754,8 @@ function resolveChokidarOptions(options$1, resolvedOutDirs, emptyOutDir, cacheDi
+ 	};
+ }
+ function convertToNotifyOptions(options$1) {
+-	if (!options$1) return;
+-	return { pollInterval: options$1.usePolling ? options$1.interval ?? 100 : void 0 };
++	if (!options$1 || !options$1.usePolling) return;
++	return { pollInterval: options$1.interval ?? 100 };
+ }
+ var NoopWatcher = class extends EventEmitter {
+ 	constructor(options$1) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-pbAhz4S9ckQT1t7W1ZdC6RssHIxKgH+QX6pai/FBocY=
 
+patchedDependencies:
+  rolldown-vite@7.3.1:
+    hash: 443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f
+    path: patches/rolldown-vite@7.3.1.patch
+
 importers:
 
   .:
@@ -50,7 +55,7 @@ importers:
         version: 7.0.0-dev.20260309.1
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 5.1.4(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       baseline-browser-mapping:
         specifier: ^2.9.14
         version: 2.10.0
@@ -89,10 +94,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: npm:rolldown-vite@7.3.1
-        version: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+        version: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
       vite-plugin-css-injected-by-js:
         specifier: ^4.0.1
-        version: 4.0.1(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.0.1(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
 
   apps/docs:
     dependencies:
@@ -113,7 +118,7 @@ importers:
         version: link:../../packages/ui
       '@tailwindcss/vite':
         specifier: ^4.2.1
-        version: 4.2.1(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.2.1(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       motion:
         specifier: ^11.18.2
         version: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -147,19 +152,19 @@ importers:
         version: link:../../packages/typescript-config
       '@storybook/addon-designs':
         specifier: ^11.0.0
-        version: 11.1.2(@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 11.1.2(@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-docs':
         specifier: ^10.0.0
-        version: 10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+        version: 10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-themes':
         specifier: ^10.0.0
         version: 10.2.16(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/addon-vitest':
         specifier: ^10.2.13
-        version: 10.2.16(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.18)
+        version: 10.2.16(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.18)
       '@storybook/react-vite':
         specifier: ^10.0.0
-        version: 10.2.16(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
+        version: 10.2.16(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       '@tailwindcss/postcss':
         specifier: ^4.1.4
         version: 4.2.1
@@ -177,10 +182,10 @@ importers:
         version: 1.8.8
       '@vitest/browser-playwright':
         specifier: ^4.0.18
-        version: 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
       playwright:
         specifier: ^1.58.2
         version: 1.58.2
@@ -207,7 +212,7 @@ importers:
         version: 1.0.7(tailwindcss@4.2.1)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
 
   packages/eslint-config:
     devDependencies:
@@ -265,10 +270,13 @@ importers:
         version: 4.0.2(postcss@8.5.8)(ts-node@10.9.2(@types/node@22.19.15)(typescript@5.9.3))
       vite-plugin-dts:
         specifier: ^4.5.4
-        version: 4.5.4(@types/node@22.19.15)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)
+        version: 4.5.4(@types/node@22.19.15)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)
 
   packages/ui:
     dependencies:
+      '@chenglou/pretext':
+        specifier: ^0.0.4
+        version: 0.0.4
       '@radix-ui/react-checkbox':
         specifier: ^1.2.3
         version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -374,7 +382,7 @@ importers:
         version: 18.3.28
       '@vitejs/plugin-react':
         specifier: ^5.1.4
-        version: 5.1.4(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 5.1.4(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       jsdom:
         specifier: ^28.1.0
         version: 28.1.0
@@ -383,10 +391,10 @@ importers:
         version: 0.3.18
       vite:
         specifier: npm:rolldown-vite@7.3.1
-        version: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+        version: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+        version: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
 
 packages:
 
@@ -596,6 +604,9 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
+
+  '@chenglou/pretext@0.0.4':
+    resolution: {integrity: sha512-FnPAFMid1/p1j2V2gRPUVBarGUIb2PhkkC9YNnTOfPtTDgHKh8siO8PP9pCxpFfYlcodWPJpE1UbSHGQqt8pQQ==}
 
   '@chromatic-com/storybook@5.0.1':
     resolution: {integrity: sha512-v80QBwVd8W6acH5NtDgFlUevIBaMZAh1pYpBiB40tuNzS242NTHeQHBDGYwIAbWKDnt1qfjJpcpL6pj5kAr4LA==}
@@ -7614,6 +7625,8 @@ snapshots:
   '@bufbuild/protobuf@2.11.0':
     optional: true
 
+  '@chenglou/pretext@0.0.4': {}
+
   '@chromatic-com/storybook@5.0.1(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@neoconfetti/react': 1.0.0
@@ -8151,11 +8164,11 @@ snapshots:
       wrap-ansi: 8.1.0
       wrap-ansi-cjs: wrap-ansi@7.0.0
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.4(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)':
     dependencies:
       glob: 13.0.6
       react-docgen-typescript: 2.4.0(typescript@5.9.3)
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -9069,21 +9082,21 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook/addon-designs@11.1.2(@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-designs@11.1.2(@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@figspec/react': 2.0.1(@types/react@18.3.28)(react@18.3.1)
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     optionalDependencies:
-      '@storybook/addon-docs': 10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/addon-docs': 10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/addon-docs@10.2.16(@types/react@18.3.28)(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@18.3.28)(react@18.3.1)
-      '@storybook/csf-plugin': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/csf-plugin': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react-dom-shim': 10.2.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       react: 18.3.1
@@ -9102,39 +9115,39 @@ snapshots:
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-vitest@10.2.16(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.18)':
+  '@storybook/addon-vitest@10.2.16(@vitest/browser-playwright@4.0.18)(@vitest/browser@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(@vitest/runner@4.0.18)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(vitest@4.0.18)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 2.0.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
       '@vitest/runner': 4.0.18
-      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/builder-vite@10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      '@storybook/csf-plugin': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/csf-plugin': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       ts-dedent: 2.2.0
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
       - webpack
 
-  '@storybook/csf-plugin@10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+  '@storybook/csf-plugin@10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
       esbuild: 0.25.12
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
 
   '@storybook/csf@0.0.1':
     dependencies:
@@ -9153,11 +9166,11 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@storybook/react-vite@10.2.16(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
+  '@storybook/react-vite@10.2.16(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.4(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3)
       '@rollup/pluginutils': 5.3.0
-      '@storybook/builder-vite': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@storybook/builder-vite': 10.2.16(esbuild@0.25.12)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react': 10.2.16(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.3)
       empathic: 2.0.0
       magic-string: 0.30.21
@@ -9167,7 +9180,7 @@ snapshots:
       resolve: 1.22.11
       storybook: 10.2.16(@testing-library/dom@10.4.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - esbuild
       - rollup
@@ -9259,12 +9272,12 @@ snapshots:
       postcss: 8.5.8
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
+  '@tailwindcss/vite@4.2.1(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
 
   '@tanstack/react-table@8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -9764,7 +9777,7 @@ snapshots:
       - jest
       - supports-color
 
-  '@vitejs/plugin-react@5.1.4(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitejs/plugin-react@5.1.4(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -9772,33 +9785,33 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
-      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
 
-  '@vitest/browser@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -9806,7 +9819,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18))(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -9818,10 +9831,10 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
-      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
     optionalDependencies:
-      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -9840,13 +9853,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
+  '@vitest/mocker@4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -13685,7 +13698,7 @@ snapshots:
     transitivePeerDependencies:
       - oxc-resolver
 
-  rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2):
+  rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2):
     dependencies:
       '@oxc-project/runtime': 0.101.0
       fdir: 6.5.0(picomatch@4.0.3)
@@ -14799,11 +14812,11 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-css-injected-by-js@4.0.1(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)):
+  vite-plugin-css-injected-by-js@4.0.1(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)):
     dependencies:
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
 
-  vite-plugin-dts@4.5.4(@types/node@22.19.15)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3):
+  vite-plugin-dts@4.5.4(@types/node@22.19.15)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(typescript@5.9.3):
     dependencies:
       '@microsoft/api-extractor': 7.57.6(@types/node@22.19.15)
       '@rollup/pluginutils': 5.3.0
@@ -14816,16 +14829,16 @@ snapshots:
       magic-string: 0.30.21
       typescript: 5.9.3
     optionalDependencies:
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
     transitivePeerDependencies:
       - '@types/node'
       - rollup
       - supports-color
 
-  vitest@4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)):
+  vitest@4.0.18(@types/node@22.19.15)(@vitest/browser-playwright@4.0.18)(jsdom@28.1.0)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
+      '@vitest/mocker': 4.0.18(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -14842,11 +14855,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
+      vite: rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.15
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(rolldown-vite@7.3.1(patch_hash=443ebc2838548a77a744c130cadbbed23222fdf34e5d4e744c8873326789396f)(@types/node@22.19.15)(esbuild@0.25.12)(jiti@2.6.1)(sass-embedded@1.97.3)(sass@1.97.3)(yaml@2.8.2))(vitest@4.0.18)
       jsdom: 28.1.0
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
Changes:
- Add new component TextEllipsis based on Pretext
- Add support for this component on Badge
- Little fix on rolldown-vite for refresh locally (I didn't update to vite 8 because I saw weird bugs in the past)