### PR TITLE
feat(kbd): add Kbd component

### DIFF
--- a/apps/docs/stories/kbd.mdx
+++ b/apps/docs/stories/kbd.mdx
@@ -19,23 +19,6 @@ export default function MyComponent() {
 }
 ```
 
-### Keyboard shortcut
-
-Compose multiple `Kbd` elements side by side to represent a shortcut:
-
-```tsx
-import { Kbd } from '@signozhq/ui';
-
-export default function MyComponent() {
-	return (
-		<div className="flex items-center gap-1">
-			<Kbd>⌘</Kbd>
-			<Kbd>K</Kbd>
-		</div>
-	);
-}
-```
-
 ### Active state
 
 Use `active` to highlight a key with a subtle primary color tint:

--- a/apps/docs/stories/kbd.mdx
+++ b/apps/docs/stories/kbd.mdx
@@ -1,0 +1,60 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as KbdStories from './kbd.stories';
+
+<Meta of={KbdStories} />
+
+# Kbd
+
+A keyboard key component for displaying keyboard shortcuts and key bindings. Renders as a semantic `<kbd>` HTML element.
+
+## How to use
+
+### Basic usage
+
+```tsx
+import { Kbd } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return <Kbd>⌘K</Kbd>;
+}
+```
+
+### Keyboard shortcut
+
+Compose multiple `Kbd` elements side by side to represent a shortcut:
+
+```tsx
+import { Kbd } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<div className="flex items-center gap-1">
+			<Kbd>⌘</Kbd>
+			<Kbd>K</Kbd>
+		</div>
+	);
+}
+```
+
+### Active state
+
+Use `active` to highlight a key with a subtle primary color tint:
+
+```tsx
+import { Kbd } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<div className="flex items-center gap-1">
+			<Kbd active>⌘</Kbd>
+			<Kbd>K</Kbd>
+		</div>
+	);
+}
+```
+
+<Primary />
+
+## Props
+
+<Controls of={KbdStories.Playground} />

--- a/apps/docs/stories/kbd.stories.tsx
+++ b/apps/docs/stories/kbd.stories.tsx
@@ -1,0 +1,204 @@
+import { Kbd } from '@signozhq/ui';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+const meta: Meta<typeof Kbd> = {
+	title: 'Components/Kbd',
+	component: Kbd,
+	parameters: {
+		layout: 'fullscreen',
+		docs: {
+			description: {
+				component:
+					'A keyboard key component for displaying keyboard shortcuts and key bindings. Renders as a semantic `<kbd>` element with a key-like appearance. Supports three sizes and composes with any element via `asChild`.',
+			},
+		},
+	},
+	argTypes: {
+		testId: {
+			control: 'text',
+			description: 'Test ID for the kbd element.',
+			table: { category: 'Testing', type: { summary: 'string' } },
+		},
+		id: {
+			control: 'text',
+			description: 'A unique identifier for the element.',
+			table: { category: 'Accessibility', type: { summary: 'string' } },
+		},
+		className: {
+			control: 'text',
+			description: 'Additional CSS classes for custom styling.',
+			table: { category: 'Styling', type: { summary: 'string' } },
+		},
+		children: {
+			control: 'text',
+			description: 'The key label or content.',
+			table: { category: 'Content' },
+		},
+		size: {
+			control: 'inline-radio',
+			options: ['sm', 'default', 'lg'],
+			description: 'Controls the size of the key.',
+			table: { category: 'Appearance', defaultValue: { summary: 'default' } },
+		},
+		asChild: {
+			control: 'boolean',
+			description: 'Use Radix Slot to compose as a different element.',
+			table: { category: 'Composition', defaultValue: { summary: 'false' } },
+		},
+	},
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Kbd>;
+
+export const Playground: Story = {
+	args: {
+		children: '⌘K',
+		size: 'default',
+		asChild: false,
+	},
+	render: (props) => (
+		<div className="p-4">
+			<Kbd {...props} />
+		</div>
+	),
+};
+
+export const AllSizes: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Three sizes are available: `sm`, `default`, and `lg`.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		size: { control: false },
+		asChild: { control: false },
+	},
+	render: () => (
+		<div className="flex items-center gap-3 p-4">
+			<Kbd size="sm">⌘K</Kbd>
+			<Kbd size="default">⌘K</Kbd>
+			<Kbd size="lg">⌘K</Kbd>
+		</div>
+	),
+};
+
+export const CommonKeys: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story: 'Common keyboard keys and symbols.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		size: { control: false },
+		asChild: { control: false },
+	},
+	render: () => (
+		<div className="flex flex-wrap items-center gap-2 p-4">
+			{['⌘', '⌥', '⇧', '⌃', '↵', '⌫', '⇥', 'Esc', 'Space', '↑', '↓', '←', '→'].map((key) => (
+				<Kbd key={key}>{key}</Kbd>
+			))}
+		</div>
+	),
+};
+
+export const KeyboardShortcuts: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Display keyboard shortcuts inline. Combine multiple `Kbd` elements to show modifier+key combinations.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		size: { control: false },
+		asChild: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<div>
+				<h3 className="text-sm font-medium mb-3 text-vanilla-800 dark:text-vanilla-300">
+					Common Shortcuts
+				</h3>
+				<div className="space-y-2">
+					{[
+						{ label: 'Save', keys: ['⌘', 'S'] },
+						{ label: 'Copy', keys: ['⌘', 'C'] },
+						{ label: 'Paste', keys: ['⌘', 'V'] },
+						{ label: 'Undo', keys: ['⌘', 'Z'] },
+						{ label: 'Find', keys: ['⌘', 'F'] },
+						{ label: 'Command palette', keys: ['⌘', 'K'] },
+					].map(({ label, keys }) => (
+						<div key={label} className="flex items-center justify-between max-w-xs">
+							<span className="text-sm text-vanilla-800 dark:text-vanilla-300">{label}</span>
+							<div className="flex items-center gap-1">
+								{keys.map((key, i) => (
+									<Kbd key={i}>{key}</Kbd>
+								))}
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-3 text-vanilla-800 dark:text-vanilla-300">
+					Multi-modifier
+				</h3>
+				<div className="space-y-2">
+					{[
+						{ label: 'Redo', keys: ['⌘', '⇧', 'Z'] },
+						{ label: 'Force quit', keys: ['⌘', '⌥', 'Esc'] },
+					].map(({ label, keys }) => (
+						<div key={label} className="flex items-center justify-between max-w-xs">
+							<span className="text-sm text-vanilla-800 dark:text-vanilla-300">{label}</span>
+							<div className="flex items-center gap-1">
+								{keys.map((key, i) => (
+									<Kbd key={i}>{key}</Kbd>
+								))}
+							</div>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	),
+};
+
+export const InlineText: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Use `Kbd` inline within text to reference key bindings in documentation or tooltips.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		size: { control: false },
+		asChild: { control: false },
+	},
+	render: () => (
+		<div className="space-y-3 p-4 text-sm text-vanilla-800 dark:text-vanilla-300 max-w-md">
+			<p>
+				Press <Kbd size="sm">⌘</Kbd> <Kbd size="sm">K</Kbd> to open the command palette.
+			</p>
+			<p>
+				Use <Kbd size="sm">↑</Kbd> and <Kbd size="sm">↓</Kbd> to navigate results, then{' '}
+				<Kbd size="sm">↵</Kbd> to confirm.
+			</p>
+			<p>
+				Hold <Kbd size="sm">⇧</Kbd> while clicking to select a range.
+			</p>
+		</div>
+	),
+};

--- a/apps/docs/stories/kbd.stories.tsx
+++ b/apps/docs/stories/kbd.stories.tsx
@@ -45,6 +45,11 @@ const meta: Meta<typeof Kbd> = {
 			description: 'Use Radix Slot to compose as a different element.',
 			table: { category: 'Composition', defaultValue: { summary: 'false' } },
 		},
+		active: {
+			control: 'boolean',
+			description: 'Highlights the key with a subtle primary color tint.',
+			table: { category: 'Appearance', defaultValue: { summary: 'false' } },
+		},
 	},
 };
 
@@ -57,6 +62,7 @@ export const Playground: Story = {
 		children: '⌘K',
 		size: 'default',
 		asChild: false,
+		active: false,
 	},
 	render: (props) => (
 		<div className="p-4">
@@ -199,6 +205,61 @@ export const InlineText: Story = {
 			<p>
 				Hold <Kbd size="sm">⇧</Kbd> while clicking to select a range.
 			</p>
+		</div>
+	),
+};
+
+export const ActiveState: Story = {
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Use `active` to highlight a key with a subtle primary color tint and solid primary border.',
+			},
+		},
+	},
+	argTypes: {
+		children: { control: false },
+		size: { control: false },
+		asChild: { control: false },
+		active: { control: false },
+	},
+	render: () => (
+		<div className="space-y-4 p-4">
+			<div>
+				<h3 className="text-sm font-medium mb-3 text-vanilla-800 dark:text-vanilla-300">
+					Default vs Active
+				</h3>
+				<div className="flex items-center gap-2">
+					<Kbd>⌘</Kbd>
+					<Kbd active>⌘</Kbd>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-3 text-vanilla-800 dark:text-vanilla-300">
+					All Sizes
+				</h3>
+				<div className="flex items-center gap-2">
+					<Kbd size="sm" active>
+						⌘
+					</Kbd>
+					<Kbd size="default" active>
+						⌘
+					</Kbd>
+					<Kbd size="lg" active>
+						⌘
+					</Kbd>
+				</div>
+			</div>
+			<div>
+				<h3 className="text-sm font-medium mb-3 text-vanilla-800 dark:text-vanilla-300">
+					Active Key in a Shortcut
+				</h3>
+				<div className="flex items-center gap-1">
+					<Kbd active>⌘</Kbd>
+					<Kbd>K</Kbd>
+				</div>
+			</div>
 		</div>
 	),
 };

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,7 @@ export * from './dialog/index.js';
 export * from './drawer/index.js';
 export * from './dropdown-menu/index.js';
 export * from './input/index.js';
+export * from './kbd/index.js';
 export * from './pagination/index.js';
 export * from './pin-list/index.js';
 export * from './popover/index.js';

--- a/packages/ui/src/kbd/index.ts
+++ b/packages/ui/src/kbd/index.ts
@@ -1,0 +1,2 @@
+export type * from './kbd.js';
+export { Kbd } from './kbd.js';

--- a/packages/ui/src/kbd/kbd.module.css
+++ b/packages/ui/src/kbd/kbd.module.css
@@ -31,4 +31,10 @@
         --kbd-font-size: var(--font-size-base);
         --kbd-border-radius: var(--radius-md);
     }
+
+    &[data-active] {
+        --kbd-background: var(--callout-primary-background);
+        --kbd-foreground: var(--primary-background);
+        --kbd-border-color: var(--primary-background);
+    }
 }

--- a/packages/ui/src/kbd/kbd.module.css
+++ b/packages/ui/src/kbd/kbd.module.css
@@ -3,16 +3,16 @@
     align-items: var(--kbd-align-items, center);
     justify-content: var(--kbd-justify-content, center);
     border-radius: var(--kbd-border-radius, var(--radius-sm));
-    border: var(--kbd-border-width, 1px) solid var(--kbd-border-color, var(--bg-neutral-light-700));
+    border: var(--kbd-border-width, 1px) solid var(--kbd-border-color, var(--l3-border));
     padding: var(--kbd-padding, var(--spacing-1) var(--spacing-3));
     font-size: var(--kbd-font-size, var(--periscope-font-size-small));
     line-height: var(--kbd-line-height, 1.4);
     font-weight: var(--kbd-font-weight, var(--font-weight-medium, 500));
     font-family: var(--kbd-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
     white-space: var(--kbd-white-space, nowrap);
-    background-color: var(--kbd-background, var(--bg-neutral-light-900,));
-    color: var(--kbd-foreground, var(--text-ink-300));
-    box-shadow: var(--kbd-shadow, 0 1px 0 0 var(--kbd-border-color, var(--bg-neutral-light-700)));
+    background-color: var(--kbd-background, var(--l3-background));
+    color: var(--kbd-foreground, var(--l2-foreground));
+    box-shadow: var(--kbd-shadow, 0 1px 0 0 var(--kbd-border-color, var(--l3-border)));
     user-select: none;
 
     &[data-size="sm"] {
@@ -31,10 +31,4 @@
         --kbd-font-size: var(--font-size-base);
         --kbd-border-radius: var(--radius-md);
     }
-}
-
-:global(.dark) .kbd {
-    --kbd-background: var(--bg-neutral-dark-900);
-    --kbd-foreground: var(--text-vanilla-300);
-    --kbd-border-color: var(--bg-neutral-dark-700);
 }

--- a/packages/ui/src/kbd/kbd.module.css
+++ b/packages/ui/src/kbd/kbd.module.css
@@ -1,0 +1,40 @@
+.kbd {
+    display: var(--kbd-display, inline-flex);
+    align-items: var(--kbd-align-items, center);
+    justify-content: var(--kbd-justify-content, center);
+    border-radius: var(--kbd-border-radius, var(--radius-sm));
+    border: var(--kbd-border-width, 1px) solid var(--kbd-border-color, var(--bg-neutral-light-700));
+    padding: var(--kbd-padding, var(--spacing-1) var(--spacing-3));
+    font-size: var(--kbd-font-size, var(--periscope-font-size-small));
+    line-height: var(--kbd-line-height, 1.4);
+    font-weight: var(--kbd-font-weight, var(--font-weight-medium, 500));
+    font-family: var(--kbd-font-family, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
+    white-space: var(--kbd-white-space, nowrap);
+    background-color: var(--kbd-background, var(--bg-neutral-light-900,));
+    color: var(--kbd-foreground, var(--text-ink-300));
+    box-shadow: var(--kbd-shadow, 0 1px 0 0 var(--kbd-border-color, var(--bg-neutral-light-700)));
+    user-select: none;
+
+    &[data-size="sm"] {
+        --kbd-padding: var(--spacing-0) var(--spacing-2);
+        --kbd-font-size: var(--periscope-font-size-xs);
+        --kbd-border-radius: var(--radius-xs);
+    }
+
+    &[data-size="default"] {
+        --kbd-padding: var(--spacing-1) var(--spacing-3);
+        --kbd-font-size: var(--periscope-font-size-sm);
+    }
+
+    &[data-size="lg"] {
+        --kbd-padding: var(--spacing-2) var(--spacing-4);
+        --kbd-font-size: var(--font-size-base);
+        --kbd-border-radius: var(--radius-md);
+    }
+}
+
+:global(.dark) .kbd {
+    --kbd-background: var(--bg-neutral-dark-900);
+    --kbd-foreground: var(--text-vanilla-300);
+    --kbd-border-color: var(--bg-neutral-dark-700);
+}

--- a/packages/ui/src/kbd/kbd.tsx
+++ b/packages/ui/src/kbd/kbd.tsx
@@ -19,12 +19,18 @@ interface KbdProps
 	 * @default default
 	 */
 	size?: KbdSize;
+	/**
+	 * Highlights the key with a subtle primary color tint.
+	 * @default false
+	 */
+	active?: boolean;
 }
 
 function Kbd({
 	className,
 	size = 'default',
 	asChild = false,
+	active = false,
 	testId,
 	children,
 	...props
@@ -35,6 +41,7 @@ function Kbd({
 		<Comp
 			data-slot="kbd"
 			data-size={size}
+			data-active={active || undefined}
 			data-testid={testId}
 			className={cn(styles.kbd, className)}
 			{...props}

--- a/packages/ui/src/kbd/kbd.tsx
+++ b/packages/ui/src/kbd/kbd.tsx
@@ -1,0 +1,48 @@
+import { Slot } from '@radix-ui/react-slot';
+import type React from 'react';
+import { cn } from '../lib/utils.js';
+import styles from './kbd.module.css';
+
+type KbdSize = 'sm' | 'default' | 'lg';
+
+interface KbdProps
+	extends Pick<React.ComponentProps<'kbd'>, 'className' | 'children' | 'id' | 'style'> {
+	/**
+	 * The testId associated with the kbd element.
+	 */
+	testId?: string;
+	/**
+	 * @default false
+	 */
+	asChild?: boolean;
+	/**
+	 * @default default
+	 */
+	size?: KbdSize;
+}
+
+function Kbd({
+	className,
+	size = 'default',
+	asChild = false,
+	testId,
+	children,
+	...props
+}: KbdProps) {
+	const Comp = asChild ? Slot : 'kbd';
+
+	return (
+		<Comp
+			data-slot="kbd"
+			data-size={size}
+			data-testid={testId}
+			className={cn(styles.kbd, className)}
+			{...props}
+		>
+			{children}
+		</Comp>
+	);
+}
+
+export { Kbd };
+export type { KbdProps, KbdSize };

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -16,6 +16,7 @@ const entries: Record<string, string> = {
 	'drawer/index': 'src/drawer/index.ts',
 	'dropdown-menu/index': 'src/dropdown-menu/index.ts',
 	'input/index': 'src/input/index.ts',
+	'kbd/index': 'src/kbd/index.ts',
 	'pagination/index': 'src/pagination/index.ts',
 	'pin-list/index': 'src/pin-list/index.ts',
 	'popover/index': 'src/popover/index.ts',


### PR DESCRIPTION
## Summary

- Adds a new `Kbd` component that renders a semantic `<kbd>` HTML element with keyboard-key styling
- Supports three sizes (`sm`, `default`, `lg`) and `asChild` composition via Radix UI Slot
- Includes dark mode support and CSS custom property overrides following existing component conventions

## Screenshots
<img width="1016" height="702" alt="image" src="https://github.com/user-attachments/assets/ac32b0a7-7c52-436a-b0e3-2c71398d1994" />

<img width="408" height="79" alt="image" src="https://github.com/user-attachments/assets/24eb7299-92fd-4932-a7f4-fd5b97bec44c" />
<img width="415" height="78" alt="image" src="https://github.com/user-attachments/assets/5cdb2b6b-93dd-43c6-891a-8ba654b7a226" />
<img width="353" height="322" alt="image" src="https://github.com/user-attachments/assets/c4c9d28b-3215-4417-8d30-cd5ae425af3f" />
<img width="349" height="328" alt="image" src="https://github.com/user-attachments/assets/5e2640ee-d85f-41fe-a46b-e8d869544f8c" />




## Changes

- `packages/ui/src/kbd/kbd.tsx` — component implementation
- `packages/ui/src/kbd/kbd.module.css` — CSS module with size variants and dark mode
- `packages/ui/src/kbd/index.ts` — barrel export
- `packages/ui/src/index.ts` — registered new export
- `packages/ui/vite.config.ts` — registered new build entry
- `apps/docs/stories/kbd.stories.tsx` — Storybook stories: Playground, AllSizes, CommonKeys, KeyboardShortcuts, InlineText

## Test plan

- [ ] `pnpm build` passes without errors
- [ ] Storybook shows the `Components/Kbd` entry with all five stories
- [ ] All three sizes render correctly in light and dark mode
- [ ] `asChild` prop composes correctly with a custom element

🤖 Generated with [Claude Code](https://claude.com/claude-code)