### PR TITLE
feat(button): add ButtonGroup and forward native HTMLButtonElement attributes

### DIFF
--- a/apps/docs/stories/button-group.stories.tsx
+++ b/apps/docs/stories/button-group.stories.tsx
@@ -1,0 +1,126 @@
+import { ChevronLeft, ChevronRight, Code } from '@signozhq/icons';
+import { Button, ButtonColor, ButtonGroup, ButtonSize, ButtonVariant } from '@signozhq/ui';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { COLORS, VARIANTS } from './shared/button-arg-types.js';
+
+const meta: Meta<typeof ButtonGroup> = {
+	title: 'Components/Button/ButtonGroup',
+	component: ButtonGroup,
+	parameters: {
+		layout: 'fullscreen',
+		controls: { disable: false },
+	},
+	argTypes: {
+		variant: {
+			control: 'select',
+			options: VARIANTS,
+			description:
+				'Default `variant` applied to descendant Buttons that do not set their own `variant`.',
+			table: { defaultValue: { summary: 'solid' } },
+		},
+		size: {
+			control: 'select',
+			options: ['sm', 'md', 'icon'],
+			description: 'Default `size` applied to descendant Buttons that do not set their own `size`.',
+			table: { defaultValue: { summary: 'md' } },
+		},
+		color: {
+			control: 'select',
+			options: COLORS,
+			description:
+				'Default `color` applied to descendant Buttons that do not set their own `color`.',
+			table: { defaultValue: { summary: 'primary' } },
+		},
+		testId: {
+			control: 'text',
+			description: 'Forwarded to the rendered group element as `data-testid`.',
+		},
+	},
+	args: {
+		variant: ButtonVariant.Outlined,
+		color: ButtonColor.Secondary,
+		size: ButtonSize.MD,
+	},
+	tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ButtonGroup>;
+
+export const Default: Story = {
+	render: (args) => (
+		<ButtonGroup {...args}>
+			<Button>Day</Button>
+			<Button>Week</Button>
+			<Button>Month</Button>
+		</ButtonGroup>
+	),
+};
+
+export const Variants: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div className="p-8 flex flex-col gap-3">
+			<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
+				<Button>Day</Button>
+				<Button>Week</Button>
+				<Button>Month</Button>
+			</ButtonGroup>
+			<ButtonGroup variant={ButtonVariant.Solid}>
+				<Button>Day</Button>
+				<Button>Week</Button>
+				<Button>Month</Button>
+			</ButtonGroup>
+			<ButtonGroup variant={ButtonVariant.Ghost}>
+				<Button>Day</Button>
+				<Button>Week</Button>
+				<Button>Month</Button>
+			</ButtonGroup>
+		</div>
+	),
+};
+
+export const Sizes: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div className="p-8 flex items-end gap-4">
+			{[ButtonSize.SM, ButtonSize.MD].map((size) => (
+				<ButtonGroup
+					key={size}
+					size={size}
+					variant={ButtonVariant.Outlined}
+					color={ButtonColor.Secondary}
+				>
+					<Button>Prev</Button>
+					<Button>Next</Button>
+				</ButtonGroup>
+			))}
+		</div>
+	),
+};
+
+export const IconCluster: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div className="p-8">
+			<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary} size="icon">
+				<Button prefix={<ChevronLeft />} aria-label="Previous" />
+				<Button prefix={<Code />} aria-label="Code" />
+				<Button prefix={<ChevronRight />} aria-label="Next" />
+			</ButtonGroup>
+		</div>
+	),
+};
+
+export const PerButtonOverride: Story = {
+	parameters: { controls: { disable: true } },
+	render: () => (
+		<div className="p-8">
+			<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
+				<Button>Approve</Button>
+				<Button>Hold</Button>
+				<Button color={ButtonColor.Destructive}>Reject</Button>
+			</ButtonGroup>
+		</div>
+	),
+};

--- a/apps/docs/stories/button.mdx
+++ b/apps/docs/stories/button.mdx
@@ -1,12 +1,13 @@
-import { Meta, Canvas, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
 import * as ButtonStories from './button.stories';
+import * as ButtonGroupStories from './button-group.stories';
 import { Button } from '@signozhq/ui';
 
 <Meta of={ButtonStories} />
 
 # Button
 
-The button component is a versatile component that can be used to trigger actions in your application. It supports multiple variants, colors, and sizes.
+A versatile button that maps to a native `<button>` (or any child via `asChild`). Supports color/variant/size tokens, prefix/suffix slots, loading state, and forwards every native `HTMLButtonElement` attribute + event handler.
 
 ## How to use
 
@@ -19,15 +20,96 @@ export default function MyComponent() {
 }
 ```
 
-This code above will render the following button:
-
 <Primary />
 
-<Controls of={ButtonStories.Default} />
+## Variants
+
+`variant` controls the visual treatment. `solid` is the default; `outlined` + `dashed` work best paired with `color="secondary"`; `ghost` is a borderless text-only button; `link` styles the button as inline text; `action` reads its background from the surrounding surface (see [Action buttons](#action-buttons)).
+
+```tsx
+<Button variant="solid">Solid</Button>
+<Button variant="outlined" color="secondary">Outlined</Button>
+<Button variant="dashed" color="secondary">Dashed</Button>
+<Button variant="ghost">Ghost</Button>
+<Button variant="link">Link</Button>
+```
+
+## Colors
+
+`color` swaps the palette behind any variant. Pair with `variant` to get the right combination.
+
+```tsx
+<Button>Primary</Button>
+<Button color="destructive">Destructive</Button>
+<Button color="warning">Warning</Button>
+<Button variant="outlined" color="secondary">Secondary</Button>
+```
+
+## Sizes
+
+`size="sm"` and `size="md"` (default) cover the common cases. `size="icon"` produces a square button sized for a single icon child.
+
+```tsx
+<Button size="sm">Small</Button>
+<Button size="md">Medium</Button>
+<Button size="icon" aria-label="More"><Ellipsis /></Button>
+```
+
+## Icons (prefix / suffix)
+
+Place an icon before or after the label with `prefix` / `suffix`. For an icon-only button, combine `prefix` with `size="icon"`.
+
+```tsx
+<Button prefix={<Plus />}>Create alert</Button>
+<Button suffix={<ChevronRight />} variant="outlined" color="secondary">Next</Button>
+<Button size="icon" prefix={<Code />} aria-label="Code" />
+```
+
+## Loading
+
+`loading` disables the button and replaces the leading icon with a spinner. The `suffix` is hidden while loading.
+
+```tsx
+<Button loading prefix={<Plus />}>Saving…</Button>
+```
+
+## Action buttons
+
+`variant="action"` reads its background from the surface it's placed on via the `background` prop (`ink-500`, `ink-400`, `vanilla-100`, `vanilla-200`).
+
+```tsx
+<div className="p-6 bg-ink-500">
+	<Button variant="action" background="ink-500" prefix={<ChevronLeft />}>
+		Action
+	</Button>
+</div>
+```
+
+## `asChild`
+
+Render the button as the immediate child element (via Radix `Slot`) instead of a native `<button>`. Use this to turn a `Button` into a link while keeping its styling.
+
+```tsx
+<Button asChild variant="link" color="primary">
+	<a href="/docs">Read the docs</a>
+</Button>
+```
+
+`loading`, `prefix`, and `suffix` are not supported in this mode.
+
+## Native attributes
+
+`ButtonProps` extends `HTMLButtonElement`'s attribute surface. All standard event handlers (`onClick`, `onMouseEnter`/`Leave`, `onFocus`/`Blur`, `onKeyDown`/`Up`, etc.) plus `aria-*`, `data-*`, `tabIndex`, `id`, `title`, and `type="submit" | "button" | "reset"` are typed and forwarded.
+
+```tsx
+<form onSubmit={onSubmit}>
+	<Button type="submit">Submit</Button>
+</form>
+```
 
 ## ButtonGroup
 
-`ButtonGroup` clusters related buttons together with merged borders. `size`, `variant`, and `color` set on the group propagate to any child `Button` that doesn't set them locally.
+`ButtonGroup` is a segmented cluster of related buttons. It renders `<div role="group">` with deduped internal borders and only the outer corners rounded. `size`, `variant`, and `color` set on the group are inherited by descendant `Button`s through context — per-button props still take precedence.
 
 ```tsx
 import { Button, ButtonGroup } from '@signozhq/ui';
@@ -38,3 +120,21 @@ import { Button, ButtonGroup } from '@signozhq/ui';
 	<Button>Month</Button>
 </ButtonGroup>;
 ```
+
+Override the color of a single member without touching the rest of the group:
+
+```tsx
+<ButtonGroup variant="outlined" color="secondary">
+	<Button>Approve</Button>
+	<Button>Hold</Button>
+	<Button color="destructive">Reject</Button>
+</ButtonGroup>
+```
+
+## Button Props
+
+<Controls of={ButtonStories.Default} />
+
+## ButtonGroup Props
+
+<Controls of={ButtonGroupStories.Default} />

--- a/apps/docs/stories/button.mdx
+++ b/apps/docs/stories/button.mdx
@@ -24,3 +24,17 @@ This code above will render the following button:
 <Primary />
 
 <Controls of={ButtonStories.Default} />
+
+## ButtonGroup
+
+`ButtonGroup` clusters related buttons together with merged borders. `size`, `variant`, and `color` set on the group propagate to any child `Button` that doesn't set them locally.
+
+```tsx
+import { Button, ButtonGroup } from '@signozhq/ui';
+
+<ButtonGroup variant="outlined" color="secondary">
+	<Button>Day</Button>
+	<Button>Week</Button>
+	<Button>Month</Button>
+</ButtonGroup>;
+```

--- a/apps/docs/stories/button.stories.tsx
+++ b/apps/docs/stories/button.stories.tsx
@@ -1,12 +1,5 @@
 import { Check, ChevronLeft, ChevronRight, Code, Star, Trash } from '@signozhq/icons';
-import {
-	Button,
-	ButtonBackground,
-	ButtonColor,
-	ButtonGroup,
-	ButtonSize,
-	ButtonVariant,
-} from '@signozhq/ui';
+import { Button, ButtonBackground, ButtonColor, ButtonSize, ButtonVariant } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { buttonArgTypes, COLORS, VARIANTS } from './shared/button-arg-types.js';
@@ -400,86 +393,6 @@ export const ActionButtons: Story = {
 						</Button>
 					</div>
 				</div>
-			</div>
-		</div>
-	),
-};
-
-// ButtonGroup — merged segmented cluster of buttons (antd Button.Group equivalent)
-export const Group: Story = {
-	parameters: {
-		controls: { disable: true },
-		docs: { story: { autoplay: true } },
-	},
-	render: () => (
-		<div className="p-8 space-y-10">
-			<div className="space-y-4">
-				<h2 className="text-base font-semibold">ButtonGroup</h2>
-				<p className="text-sm text-muted-foreground">
-					Cluster related actions inline. Internal borders dedupe automatically and only the outer
-					ends are rounded. <code>size</code> / <code>variant</code> / <code>color</code> on the
-					group propagate to children that don't override them.
-				</p>
-			</div>
-
-			<div className="space-y-3">
-				<h3 className="text-sm font-medium">Variants</h3>
-				<div className="flex flex-col gap-3">
-					<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
-						<Button>Day</Button>
-						<Button>Week</Button>
-						<Button>Month</Button>
-					</ButtonGroup>
-					<ButtonGroup variant={ButtonVariant.Solid}>
-						<Button>Day</Button>
-						<Button>Week</Button>
-						<Button>Month</Button>
-					</ButtonGroup>
-					<ButtonGroup variant={ButtonVariant.Ghost}>
-						<Button>Day</Button>
-						<Button>Week</Button>
-						<Button>Month</Button>
-					</ButtonGroup>
-				</div>
-			</div>
-
-			<div className="space-y-3">
-				<h3 className="text-sm font-medium">Sizes</h3>
-				<div className="flex items-end gap-4">
-					{[ButtonSize.SM, ButtonSize.MD].map((size) => (
-						<ButtonGroup
-							key={size}
-							size={size}
-							variant={ButtonVariant.Outlined}
-							color={ButtonColor.Secondary}
-						>
-							<Button>Prev</Button>
-							<Button>Next</Button>
-						</ButtonGroup>
-					))}
-				</div>
-			</div>
-
-			<div className="space-y-3">
-				<h3 className="text-sm font-medium">Icon-only cluster</h3>
-				<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary} size="icon">
-					<Button prefix={<ChevronLeft />} aria-label="Previous" />
-					<Button prefix={<Code />} aria-label="Code" />
-					<Button prefix={<ChevronRight />} aria-label="Next" />
-				</ButtonGroup>
-			</div>
-
-			<div className="space-y-3">
-				<h3 className="text-sm font-medium">Per-button override</h3>
-				<p className="text-xs text-muted-foreground">
-					Group sets the default; individual buttons can still opt into a different color or
-					variant.
-				</p>
-				<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
-					<Button>Approve</Button>
-					<Button>Hold</Button>
-					<Button color={ButtonColor.Destructive}>Reject</Button>
-				</ButtonGroup>
 			</div>
 		</div>
 	),

--- a/apps/docs/stories/button.stories.tsx
+++ b/apps/docs/stories/button.stories.tsx
@@ -1,5 +1,12 @@
 import { Check, ChevronLeft, ChevronRight, Code, Star, Trash } from '@signozhq/icons';
-import { Button, ButtonBackground, ButtonColor, ButtonSize, ButtonVariant } from '@signozhq/ui';
+import {
+	Button,
+	ButtonBackground,
+	ButtonColor,
+	ButtonGroup,
+	ButtonSize,
+	ButtonVariant,
+} from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 import { buttonArgTypes, COLORS, VARIANTS } from './shared/button-arg-types.js';
@@ -393,6 +400,86 @@ export const ActionButtons: Story = {
 						</Button>
 					</div>
 				</div>
+			</div>
+		</div>
+	),
+};
+
+// ButtonGroup — merged segmented cluster of buttons (antd Button.Group equivalent)
+export const Group: Story = {
+	parameters: {
+		controls: { disable: true },
+		docs: { story: { autoplay: true } },
+	},
+	render: () => (
+		<div className="p-8 space-y-10">
+			<div className="space-y-4">
+				<h2 className="text-base font-semibold">ButtonGroup</h2>
+				<p className="text-sm text-muted-foreground">
+					Cluster related actions inline. Internal borders dedupe automatically and only the outer
+					ends are rounded. <code>size</code> / <code>variant</code> / <code>color</code> on the
+					group propagate to children that don't override them.
+				</p>
+			</div>
+
+			<div className="space-y-3">
+				<h3 className="text-sm font-medium">Variants</h3>
+				<div className="flex flex-col gap-3">
+					<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
+						<Button>Day</Button>
+						<Button>Week</Button>
+						<Button>Month</Button>
+					</ButtonGroup>
+					<ButtonGroup variant={ButtonVariant.Solid}>
+						<Button>Day</Button>
+						<Button>Week</Button>
+						<Button>Month</Button>
+					</ButtonGroup>
+					<ButtonGroup variant={ButtonVariant.Ghost}>
+						<Button>Day</Button>
+						<Button>Week</Button>
+						<Button>Month</Button>
+					</ButtonGroup>
+				</div>
+			</div>
+
+			<div className="space-y-3">
+				<h3 className="text-sm font-medium">Sizes</h3>
+				<div className="flex items-end gap-4">
+					{[ButtonSize.SM, ButtonSize.MD].map((size) => (
+						<ButtonGroup
+							key={size}
+							size={size}
+							variant={ButtonVariant.Outlined}
+							color={ButtonColor.Secondary}
+						>
+							<Button>Prev</Button>
+							<Button>Next</Button>
+						</ButtonGroup>
+					))}
+				</div>
+			</div>
+
+			<div className="space-y-3">
+				<h3 className="text-sm font-medium">Icon-only cluster</h3>
+				<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary} size="icon">
+					<Button prefix={<ChevronLeft />} aria-label="Previous" />
+					<Button prefix={<Code />} aria-label="Code" />
+					<Button prefix={<ChevronRight />} aria-label="Next" />
+				</ButtonGroup>
+			</div>
+
+			<div className="space-y-3">
+				<h3 className="text-sm font-medium">Per-button override</h3>
+				<p className="text-xs text-muted-foreground">
+					Group sets the default; individual buttons can still opt into a different color or
+					variant.
+				</p>
+				<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
+					<Button>Approve</Button>
+					<Button>Hold</Button>
+					<Button color={ButtonColor.Destructive}>Reject</Button>
+				</ButtonGroup>
 			</div>
 		</div>
 	),

--- a/packages/ui/src/button/button-group.module.scss
+++ b/packages/ui/src/button/button-group.module.scss
@@ -1,0 +1,32 @@
+.button-group {
+	display: var(--button-group-display, inline-flex);
+	align-items: var(--button-group-align-items, stretch);
+}
+
+/* Inner buttons share borders (overlap by 1px) and lose corner rounding. */
+.button-group > * {
+	border-radius: 0;
+	position: relative;
+}
+
+.button-group > * + * {
+	margin-left: var(--button-group-overlap, -1px);
+}
+
+.button-group > *:first-child {
+	border-top-left-radius: var(--button-group-radius, calc(var(--radius) - 2px));
+	border-bottom-left-radius: var(--button-group-radius, calc(var(--radius) - 2px));
+}
+
+.button-group > *:last-child {
+	border-top-right-radius: var(--button-group-radius, calc(var(--radius) - 2px));
+	border-bottom-right-radius: var(--button-group-radius, calc(var(--radius) - 2px));
+}
+
+/* Bring hovered / focused buttons forward so their borders aren't clipped. */
+.button-group > *:hover,
+.button-group > *:focus,
+.button-group > *:focus-visible,
+.button-group > *:active {
+	z-index: 1;
+}

--- a/packages/ui/src/button/button-group.tsx
+++ b/packages/ui/src/button/button-group.tsx
@@ -10,19 +10,69 @@ import {
 import styles from './button-group.module.scss';
 
 export type ButtonGroupProps = {
+	/**
+	 * Default `size` applied to descendant `Button`s that do not set their own `size`.
+	 * Individual buttons can still override this locally.
+	 */
 	size?: ButtonSizeValue;
+	/**
+	 * Default `variant` applied to descendant `Button`s that do not set their own `variant`.
+	 * Individual buttons can still override this locally.
+	 */
 	variant?: ButtonVariantValue;
+	/**
+	 * Default `color` applied to descendant `Button`s that do not set their own `color`.
+	 * Individual buttons can still override this locally (e.g. to mark one action destructive).
+	 */
 	color?: ButtonColorValue;
+	/**
+	 * Forwarded to the rendered group element as `data-testid`.
+	 */
 	testId?: string;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>;
 
+/**
+ * Segmented cluster of related buttons. Renders as `<div role="group">` with
+ * inline-flex children, deduped internal borders, and only the outer corners
+ * rounded. `size` / `variant` / `color` set on the group propagate to descendant
+ * `Button`s through context — per-button props still take precedence.
+ *
+ * @example
+ * ```tsx
+ * // Time-range segmented control — all three buttons share the group's variant + color
+ * <ButtonGroup variant="outlined" color="secondary">
+ *   <Button>Day</Button>
+ *   <Button>Week</Button>
+ *   <Button>Month</Button>
+ * </ButtonGroup>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Per-button override — last button opts into a destructive color
+ * <ButtonGroup variant="outlined" color="secondary">
+ *   <Button>Approve</Button>
+ *   <Button>Hold</Button>
+ *   <Button color="destructive">Reject</Button>
+ * </ButtonGroup>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Icon-only navigation cluster
+ * <ButtonGroup variant="outlined" color="secondary" size="icon">
+ *   <Button prefix={<ChevronLeft />} aria-label="Previous" />
+ *   <Button prefix={<ChevronRight />} aria-label="Next" />
+ * </ButtonGroup>
+ * ```
+ */
 const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
 	({ size, variant, color, className, children, testId, ...props }, ref) => {
 		const value = useMemo(() => ({ size, variant, color, inGroup: true }), [size, variant, color]);
 
 		return (
 			<ButtonGroupContext.Provider value={value}>
-				{/* biome-ignore lint/a11y/useSemanticElements: <div role="group"> is the standard antd-compat ButtonGroup pattern; alternatives (fieldset/menu) carry unwanted semantics. */}
+				{/* biome-ignore lint/a11y/useSemanticElements: <div role="group"> is the standard ButtonGroup pattern; alternatives (fieldset/menu) carry unwanted semantics. */}
 				<div
 					ref={ref}
 					role="group"

--- a/packages/ui/src/button/button-group.tsx
+++ b/packages/ui/src/button/button-group.tsx
@@ -1,0 +1,44 @@
+import type React from 'react';
+import { forwardRef, useMemo } from 'react';
+import { cn } from '../lib/utils.js';
+import {
+	type ButtonColorValue,
+	ButtonGroupContext,
+	type ButtonSizeValue,
+	type ButtonVariantValue,
+} from './button.js';
+import styles from './button-group.module.scss';
+
+export type ButtonGroupProps = {
+	size?: ButtonSizeValue;
+	variant?: ButtonVariantValue;
+	color?: ButtonColorValue;
+	testId?: string;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'color'>;
+
+const ButtonGroup = forwardRef<HTMLDivElement, ButtonGroupProps>(
+	({ size, variant, color, className, children, testId, ...props }, ref) => {
+		const value = useMemo(() => ({ size, variant, color, inGroup: true }), [size, variant, color]);
+
+		return (
+			<ButtonGroupContext.Provider value={value}>
+				{/* biome-ignore lint/a11y/useSemanticElements: <div role="group"> is the standard antd-compat ButtonGroup pattern; alternatives (fieldset/menu) carry unwanted semantics. */}
+				<div
+					ref={ref}
+					role="group"
+					data-testid={testId}
+					data-size={size}
+					data-variant={variant}
+					data-color={color}
+					className={cn(styles['button-group'], className)}
+					{...props}
+				>
+					{children}
+				</div>
+			</ButtonGroupContext.Provider>
+		);
+	}
+);
+ButtonGroup.displayName = 'ButtonGroup';
+
+export { ButtonGroup };

--- a/packages/ui/src/button/button.test.tsx
+++ b/packages/ui/src/button/button.test.tsx
@@ -1,7 +1,8 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { createRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import { Button, ButtonBackground, ButtonColor, ButtonVariant } from './button.js';
+import { Button, ButtonBackground, ButtonColor, ButtonSize, ButtonVariant } from './button.js';
+import { ButtonGroup } from './button-group.js';
 
 describe('Button', () => {
 	it('renders as button with default props and children', () => {
@@ -125,5 +126,87 @@ describe('Button', () => {
 	it('applies type="submit" when specified', () => {
 		render(<Button type="submit">Submit</Button>);
 		expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+	});
+
+	it('forwards native event handlers (onMouseEnter, onFocus, onKeyDown)', () => {
+		const onMouseEnter = vi.fn();
+		const onFocus = vi.fn();
+		const onKeyDown = vi.fn();
+		render(
+			<Button onMouseEnter={onMouseEnter} onFocus={onFocus} onKeyDown={onKeyDown}>
+				Hover
+			</Button>
+		);
+		const btn = screen.getByRole('button');
+		fireEvent.mouseEnter(btn);
+		fireEvent.focus(btn);
+		fireEvent.keyDown(btn, { key: 'Enter' });
+		expect(onMouseEnter).toHaveBeenCalledTimes(1);
+		expect(onFocus).toHaveBeenCalledTimes(1);
+		expect(onKeyDown).toHaveBeenCalledTimes(1);
+	});
+
+	it('forwards arbitrary aria-* and data-* attributes to the button element', () => {
+		render(
+			<Button aria-label="Toolbar action" data-foo="bar" tabIndex={-1}>
+				X
+			</Button>
+		);
+		const btn = screen.getByRole('button');
+		expect(btn).toHaveAttribute('aria-label', 'Toolbar action');
+		expect(btn).toHaveAttribute('data-foo', 'bar');
+		expect(btn).toHaveAttribute('tabindex', '-1');
+	});
+});
+
+describe('ButtonGroup', () => {
+	it('renders a group with role=group', () => {
+		render(
+			<ButtonGroup testId="g">
+				<Button>A</Button>
+				<Button>B</Button>
+			</ButtonGroup>
+		);
+		const group = screen.getByTestId('g');
+		expect(group).toHaveAttribute('role', 'group');
+	});
+
+	it('propagates size to child buttons that do not override it', () => {
+		render(
+			<ButtonGroup size={ButtonSize.SM} testId="g">
+				<Button testId="a">A</Button>
+				<Button testId="b" size={ButtonSize.MD}>
+					B
+				</Button>
+			</ButtonGroup>
+		);
+		expect(screen.getByTestId('a')).toHaveAttribute('data-size', 'sm');
+		expect(screen.getByTestId('b')).toHaveAttribute('data-size', 'md');
+	});
+
+	it('propagates variant and color to child buttons', () => {
+		render(
+			<ButtonGroup variant={ButtonVariant.Outlined} color={ButtonColor.Secondary}>
+				<Button testId="a">A</Button>
+				<Button testId="b" color={ButtonColor.Destructive}>
+					B
+				</Button>
+			</ButtonGroup>
+		);
+		const a = screen.getByTestId('a');
+		const b = screen.getByTestId('b');
+		expect(a).toHaveAttribute('data-variant', 'outlined');
+		expect(a).toHaveAttribute('data-color', 'secondary');
+		expect(b).toHaveAttribute('data-color', 'destructive');
+	});
+
+	it('forwards ref to the group element', () => {
+		const ref = createRef<HTMLDivElement>();
+		render(
+			<ButtonGroup ref={ref}>
+				<Button>A</Button>
+			</ButtonGroup>
+		);
+		expect(ref.current).toBeInstanceOf(HTMLDivElement);
 	});
 });

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -70,17 +70,114 @@ export function buttonVariants({
 }
 
 export type ButtonProps = {
+	/**
+	 * Visual style of the button.
+	 * @default 'solid'
+	 */
 	variant?: ButtonVariantValue;
+	/**
+	 * Height + padding token. `'icon'` produces a square button suitable for a single icon child.
+	 * @default 'md'
+	 */
 	size?: ButtonSizeValue;
+	/**
+	 * When `true`, render as the immediate child element (via Radix `Slot`) instead of a native
+	 * `<button>`. Useful for turning a `Button` into a link. `loading`, `prefix`, and `suffix`
+	 * are not supported in this mode.
+	 * @default false
+	 */
 	asChild?: boolean;
+	/**
+	 * Color scheme applied to the variant. Maps to the button's `data-color` attribute and the
+	 * matching CSS custom properties.
+	 * @default 'primary'
+	 */
 	color?: ButtonColorValue;
+	/**
+	 * Element rendered before the button label. Sized + class-injected automatically when no
+	 * `size` prop is set on the element.
+	 */
 	prefix?: React.ReactElement;
+	/**
+	 * Element rendered after the button label. Sized + class-injected automatically when no
+	 * `size` prop is set on the element.
+	 */
 	suffix?: React.ReactElement;
+	/**
+	 * When `true`, replaces `prefix` (and hides `suffix`) with a spinner and disables the button.
+	 * @default false
+	 */
 	loading?: boolean;
+	/**
+	 * Background context for `variant="action"`. Only meaningful when `variant` is `"action"`.
+	 */
 	background?: ButtonBackgroundValue;
+	/**
+	 * Forwarded to the rendered element as `data-testid`.
+	 */
 	testId?: string;
 } & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'prefix' | 'color'>;
 
+/**
+ * Versatile button that maps to a native `<button>` (or any child via `asChild`).
+ * Supports color/variant/size tokens, prefix/suffix slots, loading state, and forwards
+ * every native `HTMLButtonElement` attribute + event handler.
+ *
+ * When nested inside `ButtonGroup`, `size`, `variant`, and `color` defaults are
+ * inherited from the group; per-button props still win.
+ *
+ * @example
+ * ```tsx
+ * // Default — solid primary
+ * <Button onClick={save}>Save</Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Outlined secondary with a leading icon
+ * <Button variant="outlined" color="secondary" prefix={<Plus />}>
+ *   Create alert
+ * </Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Destructive ghost with a trailing icon
+ * <Button variant="ghost" color="destructive" suffix={<Trash />}>
+ *   Delete
+ * </Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Icon-only square button
+ * <Button size="icon" variant="outlined" color="secondary" aria-label="More">
+ *   <Ellipsis />
+ * </Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Loading state — disables the button and replaces the prefix with a spinner
+ * <Button loading prefix={<Plus />}>Saving…</Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // `asChild` — render as a link with button styling
+ * <Button asChild variant="link" color="primary">
+ *   <a href="/docs">Read the docs</a>
+ * </Button>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Native HTML submit button inside a form
+ * <form onSubmit={onSubmit}>
+ *   <Button type="submit">Submit</Button>
+ * </form>
+ * ```
+ */
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	(
 		{

--- a/packages/ui/src/button/button.tsx
+++ b/packages/ui/src/button/button.tsx
@@ -1,7 +1,7 @@
 import { Slot } from '@radix-ui/react-slot';
 import { LoaderCircle } from '@signozhq/icons';
 import type React from 'react';
-import { cloneElement, forwardRef } from 'react';
+import { cloneElement, createContext, forwardRef, useContext } from 'react';
 import { cn } from '../lib/utils.js';
 import styles from './button.module.scss';
 
@@ -41,6 +41,19 @@ export type ButtonBackgroundValue = (typeof ButtonBackground)[keyof typeof Butto
 export type ButtonColorValue = (typeof ButtonColor)[keyof typeof ButtonColor] | (string & {});
 
 /**
+ * Context used by `ButtonGroup` to propagate `size`, `variant`, and `color` to
+ * descendant `Button`s. Children may still override any of these locally.
+ */
+export interface ButtonGroupContextValue {
+	size?: ButtonSizeValue;
+	variant?: ButtonVariantValue;
+	color?: ButtonColorValue;
+	inGroup: boolean;
+}
+
+export const ButtonGroupContext = createContext<ButtonGroupContextValue | null>(null);
+
+/**
  * Helper function to generate button class names for use in other components
  * This replaces the old CVA-based buttonVariants function
  */
@@ -66,23 +79,7 @@ export type ButtonProps = {
 	loading?: boolean;
 	background?: ButtonBackgroundValue;
 	testId?: string;
-	/**
-	 * Inline styles applied to the default trigger button. Ignored when using a custom `trigger`.
-	 */
-	style?: React.CSSProperties;
-} & Pick<
-	React.ButtonHTMLAttributes<HTMLButtonElement>,
-	| 'disabled'
-	| 'onClick'
-	| 'className'
-	| 'children'
-	| 'onDoubleClick'
-	| 'type'
-	| 'id'
-	| 'tabIndex'
-	| 'title'
-> &
-	React.AriaAttributes;
+} & Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'prefix' | 'color'>;
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 	(
@@ -104,10 +101,11 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
 		ref
 	) => {
 		const Comp = asChild ? Slot : 'button';
+		const group = useContext(ButtonGroupContext);
 
-		variant ??= ButtonVariant.Solid;
-		size ??= ButtonSize.MD;
-		color ??= ButtonColor.Primary;
+		variant ??= group?.variant ?? ButtonVariant.Solid;
+		size ??= group?.size ?? ButtonSize.MD;
+		color ??= group?.color ?? ButtonColor.Primary;
 
 		const iconSizes: Record<ButtonSizeValue, number> = {
 			[ButtonSize.SM]: 12,

--- a/packages/ui/src/button/index.ts
+++ b/packages/ui/src/button/index.ts
@@ -3,7 +3,10 @@ export {
 	Button,
 	ButtonBackground,
 	ButtonColor,
+	ButtonGroupContext,
 	ButtonSize,
 	ButtonVariant,
 	buttonVariants,
 } from './button.js';
+export type * from './button-group.js';
+export { ButtonGroup } from './button-group.js';


### PR DESCRIPTION
Unblocks the SigNoz frontend's antd Button -> @signozhq/ui Button migration.

* ButtonProps now extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'prefix' | 'color'>,
  so all native event handlers (onMouseEnter/Leave, onFocus/Blur, onKeyDown/Up, etc.),
  aria-*, data-*, tabIndex, id, and title are typed and forwarded to the underlying
  <button>. Consumers wiring Tooltip/Popover/Dropdown triggers no longer need
  @ts-expect-error workarounds.
* New ButtonGroup component (named export) renders <div role="group"> with merged
  borders: zero gap, internal borders deduped via -1px overlap, outer corners
  rounded only on the first/last child. size/variant/color set on the group
  propagate to descendant Buttons via React context; children may still override.
* button.mdx gains an antd migration table (prop mappings, htmlType -> type,
  icon -> prefix, Button.Group -> <ButtonGroup>) and a callout for the
  default-color behavior change (bare <Button> is solid+primary here, not
  outlined+grey like antd).


Closes https://github.com/SigNoz/engineering-pod/issues/4985