### PR TITLE
fix(tooltip): raise default z-index above antd overlay surfaces

### DIFF
--- a/packages/ui/src/tooltip/tooltip.module.css
+++ b/packages/ui/src/tooltip/tooltip.module.css
@@ -23,9 +23,12 @@
 .tooltip__content {
 	background-color: var(--tooltip-background, var(--l2-background));
 	color: var(--tooltip-foreground, var(--l1-foreground));
-	z-index: var(--tooltip-z-index, 50);
+	z-index: var(--tooltip-z-index, 1100);
 	width: var(--tooltip-width, fit-content);
-	transform-origin: var(--tooltip-transform-origin, var(--radix-tooltip-content-transform-origin));
+	transform-origin: var(
+		--tooltip-transform-origin,
+		var(--radix-tooltip-content-transform-origin)
+	);
 	border-radius: var(--tooltip-border-radius, calc(var(--radius-sm) - 4px));
 	padding: var(--tooltip-padding, var(--spacing-2) var(--spacing-4));
 	font-size: var(--tooltip-font-size, var(--periscope-font-size-small));
@@ -38,17 +41,16 @@
 	box-shadow: var(--tooltip-box-shadow, 0 6px 12px 0 rgba(0, 0, 0, 0.2));
 }
 
-.tooltip__content[data-state="open"] {
+.tooltip__content[data-state='open'] {
 	animation: tooltip-in 0.15s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
-.tooltip__content[data-state="closed"] {
+.tooltip__content[data-state='closed'] {
 	animation: tooltip-out 0.1s cubic-bezier(0.16, 1, 0.3, 1) forwards;
 }
 
-
 .tooltip__arrow {
-	z-index: calc(var(--tooltip-z-index, 50) + 1);
+	z-index: calc(var(--tooltip-z-index, 1100) + 1);
 	width: var(--tooltip-arrow-width, 10px);
 	height: var(--tooltip-arrow-height, 10px);
 	border-radius: var(--tooltip-arrow-border-radius, 2px);


### PR DESCRIPTION
## Summary
- Raise the default `--tooltip-z-index` fallback from `50` to `1100` so the design-system Tooltip renders above antd's Drawer/Modal (z-index `1000`) and antd's own Tooltip (`1070`) out of the box.
- Update both `.tooltip__content` and `.tooltip__arrow` fallbacks to stay in sync (arrow remains `content + 1`).
- Consumers can still override via `--tooltip-z-index` on a wrapper class where stricter stacking is needed — the multiple per-call-site overrides currently living in the SigNoz app codebase can now be cleaned up.

Refs: SigNoz/signoz#11364