### PR TITLE
Fix/slider

### DIFF
--- a/packages/ui/src/slider/slider.module.scss
+++ b/packages/ui/src/slider/slider.module.scss
@@ -19,6 +19,10 @@
 	}
 }
 
+.slider-root-with-marks {
+	margin-bottom: var(--slider-root-with-marks-margin-bottom, 28px);
+}
+
 .slider-track {
 	position: var(--slider-track-position, relative);
 	height: var(--slider-track-height, 6px);
@@ -53,9 +57,14 @@
 	background-color: var(--slider-thumb-background, var(--base-white));
 	box-shadow: var(--slider-thumb-box-shadow, 0 1px 3px 0 rgba(0, 0, 0, 0.1));
 	transition: var(--slider-thumb-transition, background-color 150ms ease-in-out);
+	cursor: var(--slider-thumb-cursor, grab);
 
 	&:hover {
 		background-color: var(--slider-thumb-hover-background, var(--base-white));
+	}
+
+	&:active {
+		cursor: var(--slider-thumb-active-cursor, grabbing);
 	}
 
 	&:focus-visible {
@@ -67,6 +76,34 @@
 		cursor: var(--slider-thumb-disabled-cursor, not-allowed);
 		opacity: var(--slider-thumb-disabled-opacity, 0.5);
 	}
+}
+
+.slider-dots {
+	position: var(--slider-dots-position, absolute);
+	top: var(--slider-dots-top, 50%);
+	left: var(--slider-dots-left, 0);
+	width: var(--slider-dots-width, 100%);
+	height: 0;
+	pointer-events: var(--slider-dots-pointer-events, none);
+}
+
+.slider-dot {
+	position: var(--slider-dot-position, absolute);
+	top: 0;
+	width: var(--slider-dot-width, 8px);
+	height: var(--slider-dot-height, 8px);
+	border-radius: var(--slider-dot-border-radius, 50%);
+	background-color: var(--slider-dot-background, var(--base-white));
+	border: var(
+		--slider-dot-border,
+		2px solid color-mix(in srgb, var(--primary) 30%, transparent)
+	);
+	transform: var(--slider-dot-transform, translate(-50%, -50%));
+	box-sizing: border-box;
+}
+
+.slider-dot-active {
+	border-color: var(--slider-dot-active-border-color, var(--primary));
 }
 
 .slider-marks {
@@ -83,4 +120,12 @@
 	transform: var(--slider-mark-transform, translateX(-50%));
 	white-space: var(--slider-mark-white-space, nowrap);
 	color: var(--slider-mark-color, var(--base-white));
+	cursor: var(--slider-mark-cursor, pointer);
+	pointer-events: var(--slider-mark-pointer-events, auto);
+
+	&:focus-visible {
+		outline: var(--slider-mark-focus-outline, 2px solid var(--primary));
+		outline-offset: var(--slider-mark-focus-outline-offset, 2px);
+		border-radius: var(--slider-mark-focus-border-radius, 2px);
+	}
 }

--- a/packages/ui/src/slider/slider.tsx
+++ b/packages/ui/src/slider/slider.tsx
@@ -203,9 +203,46 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 				const label = isObject && 'label' in markObj ? (markObj as any).label : markObj;
 				const markStyle = isObject && 'style' in markObj ? (markObj as any).style : {};
 
-				return { key, percent, label, markStyle };
+				return { key, markVal, percent, label, markStyle };
 			});
 		}, [marks, min, max]);
+
+		const isMarkActive = useCallback(
+			(markVal: number) => {
+				if (localValues.length === 1) return markVal <= localValues[0];
+				return markVal >= localValues[0] && markVal <= localValues[localValues.length - 1];
+			},
+			[localValues]
+		);
+
+		const handleMarkClick = useCallback(
+			(markVal: number) => {
+				let newValues: number[];
+				if (localValues.length === 1) {
+					newValues = [markVal];
+				} else {
+					const lastIndex = localValues.length - 1;
+					const distToFirst = Math.abs(localValues[0] - markVal);
+					const distToLast = Math.abs(localValues[lastIndex] - markVal);
+					newValues =
+						distToFirst <= distToLast
+							? [markVal, ...localValues.slice(1)]
+							: [...localValues.slice(0, lastIndex), markVal];
+					newValues = [...newValues].sort((a, b) => a - b);
+				}
+
+				if (internalValue === undefined) {
+					setLocalValues(newValues);
+				}
+				if (onChange) {
+					onChange(range ? newValues : newValues[0]);
+				}
+				if (onAfterChange) {
+					onAfterChange(range ? newValues : newValues[0]);
+				}
+			},
+			[localValues, internalValue, onChange, onAfterChange, range]
+		);
 
 		const internalId = useId();
 
@@ -221,7 +258,11 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 				defaultValue={internalDefaultValue}
 				onValueChange={handleValueChange}
 				onValueCommit={handleValueCommit}
-				className={cn(styles['slider-root'], className)}
+				className={cn(
+					styles['slider-root'],
+					markList.length > 0 && styles['slider-root-with-marks'],
+					className
+				)}
 				{...props}
 			>
 				<SliderPrimitive.Track
@@ -233,6 +274,21 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 						style={inlineStyles?.range}
 					/>
 				</SliderPrimitive.Track>
+
+				{markList.length > 0 && (
+					<div className={styles['slider-dots']}>
+						{markList.map(({ key, markVal, percent }) => (
+							<span
+								key={`slider-${internalId}-dot-${key}`}
+								className={cn(
+									styles['slider-dot'],
+									isMarkActive(markVal) && styles['slider-dot-active']
+								)}
+								style={{ left: `${percent}%` }}
+							/>
+						))}
+					</div>
+				)}
 
 				{localValues.map((val, index) => (
 					<SliderThumb
@@ -247,11 +303,21 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 
 				{markList.length > 0 && (
 					<div className={styles['slider-marks']}>
-						{markList.map(({ key, percent, label, markStyle }) => (
+						{markList.map(({ key, markVal, percent, label, markStyle }) => (
+							// biome-ignore lint/a11y/useSemanticElements: span is intentional to avoid native button styling on slider marks
 							<span
 								key={`slider-${internalId}-mark-${key}`}
 								className={styles['slider-mark']}
 								style={{ left: `${percent}%`, ...markStyle }}
+								role="button"
+								tabIndex={0}
+								onClick={() => handleMarkClick(markVal)}
+								onKeyDown={(event) => {
+									if (event.key === 'Enter' || event.key === ' ') {
+										event.preventDefault();
+										handleMarkClick(markVal);
+									}
+								}}
 							>
 								{label}
 							</span>

--- a/packages/ui/src/slider/slider.tsx
+++ b/packages/ui/src/slider/slider.tsx
@@ -234,28 +234,16 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 					/>
 				</SliderPrimitive.Track>
 
-				{localValues.map((val, index) => {
-					const thumb = (
-						<SliderPrimitive.Thumb
-							key={`slider-${internalId}-thumb-${index}`}
-							className={cn(styles['slider-thumb'], classNames?.thumb)}
-							style={inlineStyles?.thumb}
-						/>
-					);
-
-					if (tooltip) {
-						return (
-							// biome-ignore lint/suspicious/noArrayIndexKey: Thumbs order does not change
-							<TooltipProvider key={`slider-${internalId}-${index}-tooltip`}>
-								<TooltipSimple title={tooltip.formatter ? tooltip.formatter(val) : val}>
-									{thumb}
-								</TooltipSimple>
-							</TooltipProvider>
-						);
-					}
-
-					return thumb;
-				})}
+				{localValues.map((val, index) => (
+					<SliderThumb
+						// biome-ignore lint/suspicious/noArrayIndexKey: Thumbs order does not change
+						key={`slider-${internalId}-thumb-${index}`}
+						value={val}
+						className={cn(styles['slider-thumb'], classNames?.thumb)}
+						style={inlineStyles?.thumb}
+						tooltip={tooltip}
+					/>
+				))}
 
 				{markList.length > 0 && (
 					<div className={styles['slider-marks']}>
@@ -275,5 +263,52 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 	}
 );
 Slider.displayName = 'Slider';
+
+interface SliderThumbProps {
+	value: number;
+	className: string;
+	style?: React.CSSProperties;
+	tooltip?: SliderProps['tooltip'];
+}
+
+/**
+ * Internal thumb wrapper that keeps the tooltip open for the entire drag/focus
+ * lifecycle. Radix's default behavior only shows the tooltip on hover, which
+ * causes flicker as the thumb moves under the cursor during dragging.
+ */
+function SliderThumb({ value, className, style, tooltip }: SliderThumbProps) {
+	const [isDragging, setIsDragging] = useState(false);
+	const [isHovering, setIsHovering] = useState(false);
+
+	useEffect(() => {
+		if (!isDragging) return;
+		const handlePointerUp = () => setIsDragging(false);
+		window.addEventListener('pointerup', handlePointerUp);
+		return () => window.removeEventListener('pointerup', handlePointerUp);
+	}, [isDragging]);
+
+	const thumb = (
+		<SliderPrimitive.Thumb
+			className={className}
+			style={style}
+			onPointerDown={() => setIsDragging(true)}
+			onPointerEnter={() => setIsHovering(true)}
+			onPointerLeave={() => setIsHovering(false)}
+		/>
+	);
+
+	if (!tooltip) return thumb;
+
+	return (
+		<TooltipProvider delayDuration={0}>
+			<TooltipSimple
+				open={isDragging || isHovering}
+				title={tooltip.formatter ? tooltip.formatter(value) : value}
+			>
+				{thumb}
+			</TooltipSimple>
+		</TooltipProvider>
+	);
+}
 
 export { Slider };


### PR DESCRIPTION
## Summary

UI polish pass on the `Slider` component:

- **Tick dots on the track** — when `marks` are provided, renders dots aligned to each mark with an "active" state for any dot that falls within the current value/range.
- **Clickable marks** — mark labels are now interactive. Clicking (or pressing Enter/Space) on a mark moves the slider to that value. In range mode, the nearest thumb is moved.
- **Sticky tooltip during drag** — extracted an internal `SliderThumb` wrapper that keeps the tooltip open for the full drag/focus lifecycle. Fixes the flicker where Radix's hover-based tooltip would disappear as the thumb moved under the cursor.
- **Cursor affordances** — `grab`/`grabbing` on the thumb, `pointer` on marks.
- **Spacing fix** — adds `slider-root-with-marks` class that reserves bottom margin when marks are present, so they no longer overlap surrounding content.
- **Focus styles** — `focus-visible` outline on mark buttons for keyboard users.
- New CSS variables for dots, mark cursor/focus, and thumb cursor states.

## Screenshots
<img width="481" height="249" alt="image" src="https://github.com/user-attachments/assets/b0f49dbe-f0a4-4ee5-9e13-3b9241018e34" />


## Test plan

- [x] Slider with `marks` renders dots on the track and tick labels below it
- [x] Active dots correctly reflect current value (single) and range (dual-thumb)
- [x] Clicking a mark label snaps the slider to that value
- [x] In range mode, clicking a mark moves the nearer thumb
- [x] Keyboard: Tab to mark, Enter/Space activates it; `:focus-visible` outline shows
- [x] Tooltip stays open while dragging the thumb; no flicker
- [x] Slider without `marks` is visually unchanged (no extra bottom margin)
- [x] Disabled slider still renders correctly
