### PR TITLE
fix: cursor pointer + event propagation issue

### DIFF
--- a/packages/ui/src/dropdown-menu/dropdown-menu.module.scss
+++ b/packages/ui/src/dropdown-menu/dropdown-menu.module.scss
@@ -242,6 +242,10 @@
 			color: var(--dropdown-menu-item-destructive-hover-foreground, var(--danger-background-hover));
 		}
 	}
+
+	&--clickable {
+		cursor: pointer;
+	}
 }
 
 .dropdown-menu__item-icon {

--- a/packages/ui/src/dropdown-menu/presets/dropdown-menu-simple.tsx
+++ b/packages/ui/src/dropdown-menu/presets/dropdown-menu-simple.tsx
@@ -180,6 +180,7 @@ function renderMenuItems(items: MenuItem[], keyPath: string[] = []): React.React
 				rightIcon={baseItem.rightIcon}
 				destructive={baseItem.danger}
 				disabled={baseItem.disabled}
+				clickable={Boolean(baseItem.onClick)}
 				onSelect={handleSelect}
 				className={baseItem.className}
 			>

--- a/packages/ui/src/dropdown-menu/subcomponents/dropdown-menu-content.tsx
+++ b/packages/ui/src/dropdown-menu/subcomponents/dropdown-menu-content.tsx
@@ -131,6 +131,14 @@ export type DropdownMenuContentProps = {
 	 * Event handler called when a key is pressed within the content.
 	 */
 	onKeyDown?: React.KeyboardEventHandler<HTMLDivElement>;
+	/**
+	 * Event handler called when the content is clicked. The default behavior
+	 * stops the synthetic click from bubbling further up the React tree so
+	 * menu interactions never trigger `onClick` handlers on ancestor elements
+	 * (e.g. a clickable row that wraps the trigger). The handler still runs
+	 * before propagation is stopped.
+	 */
+	onClick?: React.MouseEventHandler<HTMLDivElement>;
 };
 
 /**
@@ -162,7 +170,7 @@ export type DropdownMenuContentProps = {
 export const DropdownMenuContent = React.forwardRef<
 	React.ElementRef<typeof DropdownMenuPrimitive.Content>,
 	DropdownMenuContentProps
->(({ className, sideOffset = 4, testId, id, ...props }, ref) => (
+>(({ className, sideOffset = 4, testId, id, onClick, ...props }, ref) => (
 	<DropdownMenuPortal>
 		<DropdownMenuPrimitive.Content
 			ref={ref}
@@ -171,6 +179,13 @@ export const DropdownMenuContent = React.forwardRef<
 			id={id}
 			sideOffset={sideOffset}
 			className={cn(styles['dropdown-menu__content'], className)}
+			onClick={(event): void => {
+				onClick?.(event);
+				// React synthetic clicks bubble through portals — without
+				// stopping here, every menu-item click would also fire the
+				// `onClick` of any clickable ancestor that wraps the trigger.
+				event.stopPropagation();
+			}}
 			{...props}
 		/>
 	</DropdownMenuPortal>

--- a/packages/ui/src/dropdown-menu/subcomponents/dropdown-menu-item.tsx
+++ b/packages/ui/src/dropdown-menu/subcomponents/dropdown-menu-item.tsx
@@ -33,6 +33,13 @@ export type DropdownMenuItemProps = Omit<
 	 */
 	destructive?: boolean;
 	/**
+	 * When `true`, renders the item with `cursor: pointer` to signal that it is
+	 * an interactive action. Defaults to the platform-menu `cursor: default`
+	 * when omitted. `DropdownMenuSimple` sets this automatically for items that
+	 * declare an `onClick` handler.
+	 */
+	clickable?: boolean;
+	/**
 	 * When `true`, prevents the user from interacting with the item.
 	 */
 	disabled?: boolean;
@@ -85,24 +92,30 @@ export type DropdownMenuItemProps = Omit<
 export const DropdownMenuItem = React.forwardRef<
 	React.ElementRef<typeof DropdownMenuPrimitive.Item>,
 	DropdownMenuItemProps
->(({ className, inset, leftIcon, rightIcon, destructive, children, testId, ...props }, ref) => (
-	<DropdownMenuPrimitive.Item
-		ref={ref}
-		data-slot="dropdown-menu-item"
-		data-destructive={destructive ? '' : undefined}
-		data-testid={testId}
-		className={cn(
-			styles['dropdown-menu__item'],
-			inset && styles['dropdown-menu__item--inset'],
-			destructive && styles['dropdown-menu__item--destructive'],
-			className
-		)}
-		{...props}
-	>
-		{leftIcon && <span className={styles['dropdown-menu__item-icon']}>{leftIcon}</span>}
-		{children}
-		{rightIcon && <span className={styles['dropdown-menu__item-right-icon']}>{rightIcon}</span>}
-	</DropdownMenuPrimitive.Item>
-));
+>(
+	(
+		{ className, inset, leftIcon, rightIcon, destructive, clickable, children, testId, ...props },
+		ref
+	) => (
+		<DropdownMenuPrimitive.Item
+			ref={ref}
+			data-slot="dropdown-menu-item"
+			data-destructive={destructive ? '' : undefined}
+			data-testid={testId}
+			className={cn(
+				styles['dropdown-menu__item'],
+				inset && styles['dropdown-menu__item--inset'],
+				destructive && styles['dropdown-menu__item--destructive'],
+				clickable && styles['dropdown-menu__item--clickable'],
+				className
+			)}
+			{...props}
+		>
+			{leftIcon && <span className={styles['dropdown-menu__item-icon']}>{leftIcon}</span>}
+			{children}
+			{rightIcon && <span className={styles['dropdown-menu__item-right-icon']}>{rightIcon}</span>}
+		</DropdownMenuPrimitive.Item>
+	)
+);
 
 DropdownMenuItem.displayName = 'DropdownMenuItem';


### PR DESCRIPTION
## Summary

Two small fixes to `DropdownMenu`:

- **Cursor pointer on actionable items** — added a `clickable` prop on `DropdownMenuItem` that applies `cursor: pointer`. Default stays `cursor: default` to match native menus. `DropdownMenuSimple` auto-sets `clickable` for any item that declares an `onClick` handler, so the affordance just works without callers wiring it up.
- **Stop click propagation from menu content** — `DropdownMenuContent` now calls `event.stopPropagation()` after invoking any user-provided `onClick`. React synthetic clicks bubble through portals, so previously a menu-item click would also fire the `onClick` of any clickable ancestor wrapping the trigger (e.g. a clickable row). Also exposes `onClick` on `DropdownMenuContentProps` so callers can still hook into the event.

## Test plan

- [x] Items with `onClick` (via `DropdownMenuSimple`) show pointer cursor on hover
- [x] Items without `onClick` keep the default cursor
- [x] Destructive / disabled / inset styling unchanged
- [x] Place a dropdown trigger inside a clickable row — selecting a menu item does NOT fire the row's `onClick`
- [x] User-supplied `onClick` on `DropdownMenuContent` still runs before propagation is stopped
- [x] Keyboard navigation and selection unaffected
