### PR TITLE
fix(select): remove container classname

### DIFF
--- a/packages/ui/src/__tests__/documentation.test.ts
+++ b/packages/ui/src/__tests__/documentation.test.ts
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { getComponentDirs } from './utils.js';
 
-const README_PATH = join(__dirname, '..', '..', 'README.md');
+const README_PATH = join(__dirname, '..', '..', '..', '..', 'README.md');
 const INTRO_MDX_PATH = join(
 	__dirname,
 	'..',

--- a/packages/ui/src/select/components/select-item.tsx
+++ b/packages/ui/src/select/components/select-item.tsx
@@ -6,7 +6,7 @@ import styles from '../select.module.scss';
 import { useSelectContext } from './select-context.js';
 
 export type SelectItemProps = {
-	/** Additional CSS class names for the item text container. */
+	/** Additional CSS class names for the item container. */
 	className?: string;
 	/** Inline styles for the element. */
 	style?: React.CSSProperties;
@@ -22,8 +22,6 @@ export type SelectItemProps = {
 	disabled?: boolean;
 	/** Text value for typeahead. By default uses trimmed text content. */
 	textValue?: string;
-	/** Additional CSS class names for the item container. */
-	containerClassname?: string;
 	/** Additional CSS class names for the check indicator. */
 	indicatorClassname?: string;
 };
@@ -49,54 +47,49 @@ export type SelectItemProps = {
 export const SelectItem = React.forwardRef<
 	React.ElementRef<typeof SelectPrimitive.Item>,
 	SelectItemProps
->(
-	(
-		{ className, style, id, testId, containerClassname, indicatorClassname, children, ...props },
-		ref
-	) => {
-		const context = useSelectContext();
-		const isSelected = context?.value.includes(props.value) ?? false;
+>(({ className, style, id, testId, indicatorClassname, children, ...props }, ref) => {
+	const context = useSelectContext();
+	const isSelected = context?.value.includes(props.value) ?? false;
 
-		// For multi-select, prevent Radix from closing and handle selection ourselves
-		const handlePointerUp = (e: React.PointerEvent) => {
-			if (context?.multiple && !props.disabled) {
-				e.preventDefault();
-				context.onValueChange(props.value);
-			}
-		};
+	// For multi-select, prevent Radix from closing and handle selection ourselves
+	const handlePointerUp = (e: React.PointerEvent) => {
+		if (context?.multiple && !props.disabled) {
+			e.preventDefault();
+			context.onValueChange(props.value);
+		}
+	};
 
-		return (
-			<SelectPrimitive.Item
-				ref={ref}
-				id={id}
-				className={cn(styles.select__item, containerClassname)}
-				style={style}
-				data-slot="select-item"
-				data-testid={testId}
-				data-selected={isSelected}
-				data-multiple={context?.multiple || undefined}
-				onPointerUp={handlePointerUp}
-				{...props}
-			>
-				{context?.multiple && (
-					<span
-						className={cn(styles['select__item-indicator'], indicatorClassname, {
-							'opacity-0': !isSelected,
-						})}
-					>
-						<SelectPrimitive.ItemIndicator>
-							<Check />
-						</SelectPrimitive.ItemIndicator>
-						{isSelected && !props.disabled && <Check />}
-					</span>
-				)}
-				<SelectPrimitive.ItemText>
-					<span className={cn(styles.select__item__container, className)}>{children}</span>
-				</SelectPrimitive.ItemText>
-			</SelectPrimitive.Item>
-		);
-	}
-);
+	return (
+		<SelectPrimitive.Item
+			ref={ref}
+			id={id}
+			className={cn(styles.select__item, className)}
+			style={style}
+			data-slot="select-item"
+			data-testid={testId}
+			data-selected={isSelected}
+			data-multiple={context?.multiple || undefined}
+			onPointerUp={handlePointerUp}
+			{...props}
+		>
+			{context?.multiple && (
+				<span
+					className={cn(styles['select__item-indicator'], indicatorClassname, {
+						'opacity-0': !isSelected,
+					})}
+				>
+					<SelectPrimitive.ItemIndicator>
+						<Check />
+					</SelectPrimitive.ItemIndicator>
+					{isSelected && !props.disabled && <Check />}
+				</span>
+			)}
+			<SelectPrimitive.ItemText>
+				<span className={styles.select__item__container}>{children}</span>
+			</SelectPrimitive.ItemText>
+		</SelectPrimitive.Item>
+	);
+});
 SelectItem.displayName = 'SelectItem';
 
 export type SelectItemTextProps = {

--- a/packages/ui/src/select/components/select-trigger.tsx
+++ b/packages/ui/src/select/components/select-trigger.tsx
@@ -6,10 +6,8 @@ import styles from '../select.module.scss';
 import { useSelectContext } from './select-context.js';
 
 export type SelectTriggerProps = {
-	/** Additional CSS class names. */
+	/** Additional CSS class names for the trigger container. */
 	className?: string;
-	/** Additional CSS class names for the Select Trigger Container. */
-	containerClassname?: string;
 	/** Inline styles for the element. */
 	style?: React.CSSProperties;
 	/** Unique identifier for the element. */
@@ -72,7 +70,6 @@ export const SelectTrigger = React.forwardRef<
 	(
 		{
 			className,
-			containerClassname,
 			style,
 			id,
 			testId,
@@ -109,7 +106,7 @@ export const SelectTrigger = React.forwardRef<
 					<span className={styles.select__pills}>
 						{displayedValues.map((v) => (
 							<span key={v} className={styles.select__pill}>
-								<span className={cn(styles['select__pill-text'], className)}>
+								<span className={styles['select__pill-text']}>
 									{resolveLabel ? resolveLabel(v) : v}
 								</span>
 								<button
@@ -135,17 +132,17 @@ export const SelectTrigger = React.forwardRef<
 
 			// Single-select: use resolveLabel if provided and has value, otherwise use Radix default
 			if (resolveLabel && hasValue && context) {
-				return <span className={className}>{resolveLabel(context.value[0])}</span>;
+				return <span>{resolveLabel(context.value[0])}</span>;
 			}
 
-			return <SelectPrimitive.Value className={className} placeholder={placeholder} />;
+			return <SelectPrimitive.Value placeholder={placeholder} />;
 		};
 
 		return (
 			<SelectPrimitive.Trigger
 				ref={ref}
 				id={id}
-				className={cn(styles.select__trigger, containerClassname)}
+				className={cn(styles.select__trigger, className)}
 				style={style}
 				data-slot="select-trigger"
 				data-testid={testId}


### PR DESCRIPTION
For some reason, I added the classname and containerClassname in the past, which does not make sense for this component now, this will help have a smooth transition from antd.