### PR TITLE
fix: added minor fixes related to marks in slider

### DIFF
--- a/apps/docs/stories/slider.stories.tsx
+++ b/apps/docs/stories/slider.stories.tsx
@@ -181,14 +181,15 @@ export const WithMarks: Story = {
 	args: {
 		defaultValue: 50,
 		max: 100,
-		step: 10,
+		step: 1,
 		marks: {
-			0: '0°C',
-			26: '26°C',
-			37: '37°C',
+			0: `1 GB`,
+			25: `10 GB`,
+			50: `100 GB`,
+			75: `1,000 GB`,
 			100: {
 				style: { color: '#f50' },
-				label: <strong>100°C</strong>,
+				label: <strong>10,000 GB</strong>,
 			},
 		},
 	},

--- a/packages/ui/src/slider/slider.module.scss
+++ b/packages/ui/src/slider/slider.module.scss
@@ -31,10 +31,20 @@
 	overflow: var(--slider-track-overflow, hidden);
 	border-radius: var(--slider-track-border-radius, 9999px);
 	background-color: var(--slider-track-background, color-mix(in srgb, var(--primary) 10%, transparent));
+	// Inset the track by half the thumb width on each side so its visible
+	// edges line up with the first and last marks. Radix shifts the thumb
+	// inward by `thumbWidth/2` at the extremes to keep it within bounds —
+	// matching the track keeps thumb, range fill, dots, and marks in sync.
+	margin-left: var(--slider-track-margin-x, calc(var(--slider-thumb-width, 18px) / 2));
+	margin-right: var(--slider-track-margin-x, calc(var(--slider-thumb-width, 18px) / 2));
 
 	.slider-root[data-orientation='vertical'] & {
 		width: var(--slider-track-vertical-width, 6px);
 		height: var(--slider-track-vertical-height, 100%);
+		margin-left: 0;
+		margin-right: 0;
+		margin-top: var(--slider-track-vertical-margin-y, calc(var(--slider-thumb-height, 18px) / 2));
+		margin-bottom: var(--slider-track-vertical-margin-y, calc(var(--slider-thumb-height, 18px) / 2));
 	}
 }
 
@@ -81,8 +91,11 @@
 .slider-dots {
 	position: var(--slider-dots-position, absolute);
 	top: var(--slider-dots-top, 50%);
-	left: var(--slider-dots-left, 0);
-	width: var(--slider-dots-width, 100%);
+	// Inset by half the thumb width so a dot at `${percent}%` lines up with the
+	// thumb's center — Radix shifts the thumb inward by `thumbWidth/2` at the
+	// extremes to keep it within the track bounds.
+	left: var(--slider-dots-left, calc(var(--slider-thumb-width, 18px) / 2));
+	width: var(--slider-dots-width, calc(100% - var(--slider-thumb-width, 18px)));
 	height: 0;
 	pointer-events: var(--slider-dots-pointer-events, none);
 }
@@ -94,10 +107,8 @@
 	height: var(--slider-dot-height, 8px);
 	border-radius: var(--slider-dot-border-radius, 50%);
 	background-color: var(--slider-dot-background, var(--base-white));
-	border: var(
-		--slider-dot-border,
-		2px solid color-mix(in srgb, var(--primary) 30%, transparent)
-	);
+	border: var(--slider-dot-border,
+			2px solid color-mix(in srgb, var(--primary) 30%, transparent));
 	transform: var(--slider-dot-transform, translate(-50%, -50%));
 	box-sizing: border-box;
 }
@@ -109,9 +120,10 @@
 .slider-marks {
 	position: var(--slider-marks-position, absolute);
 	top: var(--slider-marks-top, calc(50% + 12px));
-	left: var(--slider-marks-left, 0);
-	width: var(--slider-marks-width, 100%);
-	font-size: var(--slider-marks-font-size, 12px);
+	// Match the thumb's in-bounds offset so mark labels align with the thumb.
+	left: var(--slider-marks-left, calc(var(--slider-thumb-width, 18px) / 2));
+	width: var(--slider-marks-width, calc(100% - var(--slider-thumb-width, 18px)));
+	font-size: var(--slider-marks-font-size, 11px);
 	pointer-events: var(--slider-marks-pointer-events, none);
 }
 
@@ -119,7 +131,7 @@
 	position: var(--slider-mark-position, absolute);
 	transform: var(--slider-mark-transform, translateX(-50%));
 	white-space: var(--slider-mark-white-space, nowrap);
-	color: var(--slider-mark-color, var(--base-white));
+	color: var(--slider-mark-color, var(--l3-foreground));
 	cursor: var(--slider-mark-cursor, pointer);
 	pointer-events: var(--slider-mark-pointer-events, auto);
 

--- a/packages/ui/src/slider/slider.tsx
+++ b/packages/ui/src/slider/slider.tsx
@@ -254,7 +254,10 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 				data-testid={testId}
 				min={min}
 				max={max}
-				value={internalValue}
+				// Always drive Radix from localValues so handleMarkClick (which
+				// updates localValues) can actually move the thumb — Radix
+				// ignores onValueChange-only updates when it's uncontrolled.
+				value={localValues}
 				defaultValue={internalDefaultValue}
 				onValueChange={handleValueChange}
 				onValueCommit={handleValueCommit}
@@ -311,6 +314,12 @@ const Slider = React.forwardRef<React.ElementRef<typeof SliderPrimitive.Root>, S
 								style={{ left: `${percent}%`, ...markStyle }}
 								role="button"
 								tabIndex={0}
+								// Stop pointerdown from bubbling to Radix's slider root —
+								// otherwise Radix would snap the thumb to the cursor's
+								// x-position inside the label (so clicking the left edge
+								// of "10 GB" lands below 10, the right edge above 10),
+								// overriding our exact handleMarkClick(markVal) jump.
+								onPointerDown={(event) => event.stopPropagation()}
 								onClick={() => handleMarkClick(markVal)}
 								onKeyDown={(event) => {
 									if (event.key === 'Enter' || event.key === ' ') {


### PR DESCRIPTION
## Summary

Three alignment / interaction fixes for `Slider` marks, plus a story refresh:

- **Thumb, dot, mark, and track edges all align at every value.** Radix shifts the thumb inward by `thumbWidth/2` at the extremes (its `thumbInBoundsOffset`), so previously a click on the `26°C` mark left the dot peeking out from under the thumb, and the leftmost mark sat inside the visible track edge. Inset the `.slider-track` margins, `.slider-dots`, and `.slider-marks` containers by `thumbWidth/2` on each side so all four reference points share the same x-coordinate. The inset is driven by `--slider-thumb-width` (and `--slider-thumb-height` for vertical), so custom thumb sizes still line up.
- **Clicking a mark label jumps to the exact mark value.** Wide labels like "10 GB" used to land at the cursor's x (left of the label → below 10, right of the label → above 10) because Radix's `pointerdown` snap-to-cursor handler fired before our `onClick`. Stopping `pointerDown` propagation on mark elements suppresses that snap; `handleMarkClick(markVal)` now wins.
- **Make `handleMarkClick` actually drive the thumb in uncontrolled mode.** Previously `value={internalValue}` left Radix uncontrolled when no `value` prop was passed, so setting `localValues` from a mark click didn't move the thumb (only Radix's pointer snap did). Switched to `value={localValues}` — controlled mode behaves identically because `localValues` is still synced via the existing `useEffect`.
- **Storybook `WithMarks` story** swapped to GB sizes (`1 GB` → `10,000 GB`) to exercise the wide-label click case that motivated the fix. Mark font size dropped from 12px → 11px and mark color now uses `--l3-foreground` for better contrast.

## Screenshots

### Before
https://github.com/user-attachments/assets/c980c80e-f809-485c-8c1f-61ed6d0179ab


### After

https://github.com/user-attachments/assets/9d73cebf-7388-4a2e-9d40-2d191309bbe1

<img width="450" height="167" alt="image" src="https://github.com/user-attachments/assets/6e0bd9d5-8864-4c67-91b1-87d5c144eee2" />
<img width="401" height="128" alt="image" src="https://github.com/user-attachments/assets/303cf99a-4f35-4ebb-a0b0-43ebb7f0ad19" />


## Test plan

- [x] Mark labels, dots, and the thumb all sit at the same x for every value (extremes included)
- [x] Track's visible left/right edges line up with the first and last marks
- [x] Click anywhere on a wide label (`1 GB`, `10,000 GB`) — thumb snaps to the exact mark value, not the cursor x
- [x] Click on empty track still snaps to cursor position
- [x] Drag still works smoothly in both uncontrolled and controlled modes
- [x] Keyboard nav (arrows on focused thumb, Enter/Space on focused mark) unchanged
- [x] Range slider (two thumbs): mark click moves the nearer thumb
- [x] Vertical orientation: track inset applies on top/bottom instead of left/right
- [x] Consumer with custom `--slider-thumb-width` still gets correct alignment
