### PR TITLE
fix: update flex property to allow automatic sizing

### DIFF
--- a/packages/ui/src/toggle-group/toggle-group.module.scss
+++ b/packages/ui/src/toggle-group/toggle-group.module.scss
@@ -61,7 +61,7 @@
   justify-content: var(--toggle-group-item-justify-content, center);
   gap: var(--toggle-group-item-gap, var(--spacing-4, 0.5rem));
   min-width: 0;
-  flex: 1 1 0;
+  flex: 1 1 auto;
   border-radius: var(--toggle-group-item-border-radius, 0px);
   border-color: var(--toggle-group-item-border-color, transparent);
   border-width: var(--toggle-group-item-border-width, 0);


### PR DESCRIPTION
Before:

<img width="352" height="164" alt="Screenshot 2026-05-22 at 14 58 40" src="https://github.com/user-attachments/assets/593efa38-d747-4c5c-8dc2-73d61d5a8922" />


After:
<img width="362" height="126" alt="Screenshot 2026-05-22 at 14 59 09" src="https://github.com/user-attachments/assets/7a7d157a-da4c-48eb-9343-0099df2e1f0c" />
