### PR TITLE
test(badge): move badge tests out of forward-ref test file

### DIFF
--- a/packages/ui/src/badge/badge.forward-ref.test.tsx
+++ b/packages/ui/src/badge/badge.forward-ref.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { createRef } from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { Badge } from './index.js';
 
@@ -10,76 +10,5 @@ describe('Badge forwardRef', () => {
 		render(<Badge ref={ref}>Test</Badge>);
 		expect(ref.current).toBeInstanceOf(HTMLSpanElement);
 		expect(ref.current).toHaveAttribute('data-slot', 'badge');
-	});
-
-	it('renders close button only when closable', () => {
-		const { rerender } = render(<Badge>Test</Badge>);
-
-		expect(screen.queryByRole('button', { name: /close badge/i })).not.toBeInTheDocument();
-
-		rerender(<Badge closable>Test</Badge>);
-
-		expect(screen.getByRole('button', { name: /close badge/i })).toBeInTheDocument();
-	});
-
-	it('calls onClose when close button is clicked', () => {
-		const onClose = vi.fn();
-		render(
-			<Badge closable onClose={onClose}>
-				Test
-			</Badge>
-		);
-
-		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
-
-		expect(onClose).toHaveBeenCalledTimes(1);
-	});
-
-	it('hides after close button is clicked', () => {
-		render(
-			<Badge closable testId="badge">
-				Test
-			</Badge>
-		);
-
-		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
-
-		expect(screen.queryByTestId('badge')).not.toBeInTheDocument();
-	});
-
-	it('stays visible when onClose prevents default', () => {
-		render(
-			<Badge closable testId="badge" onClose={(event) => event.preventDefault()}>
-				Test
-			</Badge>
-		);
-
-		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
-
-		expect(screen.getByTestId('badge')).toBeInTheDocument();
-	});
-
-	it('renders a custom close icon', () => {
-		render(
-			<Badge closable closeIcon={<span data-testid="custom-close-icon" />}>
-				Test
-			</Badge>
-		);
-
-		expect(screen.getByTestId('custom-close-icon')).toBeInTheDocument();
-	});
-
-	it('preserves asChild rendering when closable is provided', () => {
-		render(
-			<Badge asChild closable>
-				<button type="button">Child badge</button>
-			</Badge>
-		);
-
-		expect(screen.getByRole('button', { name: /child badge/i })).toHaveAttribute(
-			'data-slot',
-			'badge'
-		);
-		expect(screen.queryByRole('button', { name: /close badge/i })).not.toBeInTheDocument();
 	});
 });

--- a/packages/ui/src/badge/badge.test.tsx
+++ b/packages/ui/src/badge/badge.test.tsx
@@ -1,0 +1,77 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Badge } from './index.js';
+
+describe('Badge closable', () => {
+	it('renders close button only when closable', () => {
+		const { rerender } = render(<Badge>Test</Badge>);
+
+		expect(screen.queryByRole('button', { name: /close badge/i })).not.toBeInTheDocument();
+
+		rerender(<Badge closable>Test</Badge>);
+
+		expect(screen.getByRole('button', { name: /close badge/i })).toBeInTheDocument();
+	});
+
+	it('calls onClose when close button is clicked', () => {
+		const onClose = vi.fn();
+		render(
+			<Badge closable onClose={onClose}>
+				Test
+			</Badge>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
+
+		expect(onClose).toHaveBeenCalledTimes(1);
+	});
+
+	it('hides after close button is clicked', () => {
+		render(
+			<Badge closable testId="badge">
+				Test
+			</Badge>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
+
+		expect(screen.queryByTestId('badge')).not.toBeInTheDocument();
+	});
+
+	it('stays visible when onClose prevents default', () => {
+		render(
+			<Badge closable testId="badge" onClose={(event) => event.preventDefault()}>
+				Test
+			</Badge>
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: /close badge/i }));
+
+		expect(screen.getByTestId('badge')).toBeInTheDocument();
+	});
+
+	it('renders a custom close icon', () => {
+		render(
+			<Badge closable closeIcon={<span data-testid="custom-close-icon" />}>
+				Test
+			</Badge>
+		);
+
+		expect(screen.getByTestId('custom-close-icon')).toBeInTheDocument();
+	});
+
+	it('preserves asChild rendering when closable is provided', () => {
+		render(
+			<Badge asChild closable>
+				<button type="button">Child badge</button>
+			</Badge>
+		);
+
+		expect(screen.getByRole('button', { name: /child badge/i })).toHaveAttribute(
+			'data-slot',
+			'badge'
+		);
+		expect(screen.queryByRole('button', { name: /close badge/i })).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
The tests for badge were added in forward-ref test file accidentally, moving out those tests from forward-ref test file to a different file https://github.com/SigNoz/components/pull/255/changes#diff-e9516fc6b171ec9755793e5b5e7cf4688eaa17ad1804eb5d4a1e1f205c202753R15-R85 