### PR TITLE
docs(storybook): split stories into Primitive and Composed Components

### DIFF
--- a/apps/docs/.storybook/preview.tsx
+++ b/apps/docs/.storybook/preview.tsx
@@ -29,7 +29,13 @@ export const parameters: Preview['parameters'] = {
 	},
 	options: {
 		storySort: {
-			order: ['Intro', 'Design System', 'Primitive Components', 'Composed Components'],
+			order: [
+				'Intro',
+				'Design System',
+				'Primitive Components',
+				'Composed Components',
+				'Old Components',
+			],
 		},
 	},
 	backgrounds: { disable: true },

--- a/apps/docs/.storybook/preview.tsx
+++ b/apps/docs/.storybook/preview.tsx
@@ -29,12 +29,7 @@ export const parameters: Preview['parameters'] = {
 	},
 	options: {
 		storySort: {
-			order: [
-				'Intro',
-				['Design System', 'Docs', '*'],
-				['Components', 'Docs', '*'],
-				['Old Components', 'Docs', '*'],
-			],
+			order: ['Intro', 'Design System', 'Primitive Components', 'Composed Components'],
 		},
 	},
 	backgrounds: { disable: true },

--- a/apps/docs/stories/alert-dialog.stories.tsx
+++ b/apps/docs/stories/alert-dialog.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof AlertDialog> = {
-	title: 'Components/Dialog/AlertDialog',
+	title: 'Composed Components/Dialog/AlertDialog',
 	component: AlertDialog,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/announcement-banner.stories.tsx
+++ b/apps/docs/stories/announcement-banner.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof AnnouncementBanner> = {
-	title: 'Components/AnnouncementBanner',
+	title: 'Composed Components/AnnouncementBanner',
 	component: AnnouncementBanner,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/avatar.stories.tsx
+++ b/apps/docs/stories/avatar.stories.tsx
@@ -2,7 +2,7 @@ import { Avatar, type AvatarColor, type AvatarSize } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Avatar> = {
-	title: 'Components/Avatar',
+	title: 'Primitive Components/Avatar',
 	component: Avatar,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/badge.stories.tsx
+++ b/apps/docs/stories/badge.stories.tsx
@@ -96,7 +96,7 @@ const StarIcon = () => (
 
 // Meta Configuration
 const meta: Meta<typeof Badge> = {
-	title: 'Components/Badge',
+	title: 'Primitive Components/Badge',
 	component: Badge,
 	args: {
 		onClose: fn(),

--- a/apps/docs/stories/breadcrumb-dropdown.stories.tsx
+++ b/apps/docs/stories/breadcrumb-dropdown.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 const meta: Meta<typeof BreadcrumbDropdown> = {
-	title: 'Components/Breadcrumb/BreadcrumbDropdown',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbDropdown',
 	component: BreadcrumbDropdown,
 	argTypes: {
 		items: {

--- a/apps/docs/stories/breadcrumb-ellipsis.stories.tsx
+++ b/apps/docs/stories/breadcrumb-ellipsis.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof BreadcrumbEllipsis> = {
-	title: 'Components/Breadcrumb/BreadcrumbEllipsis',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbEllipsis',
 	component: BreadcrumbEllipsis,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-item.stories.tsx
+++ b/apps/docs/stories/breadcrumb-item.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof BreadcrumbItem> = {
-	title: 'Components/Breadcrumb/BreadcrumbItem',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbItem',
 	component: BreadcrumbItem,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-link.stories.tsx
+++ b/apps/docs/stories/breadcrumb-link.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { fn } from 'storybook/test';
 
 const meta: Meta<typeof BreadcrumbLink> = {
-	title: 'Components/Breadcrumb/BreadcrumbLink',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbLink',
 	component: BreadcrumbLink,
 	argTypes: {
 		href: {

--- a/apps/docs/stories/breadcrumb-list.stories.tsx
+++ b/apps/docs/stories/breadcrumb-list.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof BreadcrumbList> = {
-	title: 'Components/Breadcrumb/BreadcrumbList',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbList',
 	component: BreadcrumbList,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-page.stories.tsx
+++ b/apps/docs/stories/breadcrumb-page.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof BreadcrumbPage> = {
-	title: 'Components/Breadcrumb/BreadcrumbPage',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbPage',
 	component: BreadcrumbPage,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-primitive.stories.tsx
+++ b/apps/docs/stories/breadcrumb-primitive.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Breadcrumb> = {
-	title: 'Components/Breadcrumb/Breadcrumb',
+	title: 'Primitive Components/Breadcrumb/Breadcrumb',
 	component: Breadcrumb,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-separator.stories.tsx
+++ b/apps/docs/stories/breadcrumb-separator.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof BreadcrumbSeparator> = {
-	title: 'Components/Breadcrumb/BreadcrumbSeparator',
+	title: 'Primitive Components/Breadcrumb/BreadcrumbSeparator',
 	component: BreadcrumbSeparator,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/breadcrumb-simple.stories.tsx
+++ b/apps/docs/stories/breadcrumb-simple.stories.tsx
@@ -6,7 +6,7 @@ import { fn } from 'storybook/test';
 import { breadcrumbSimpleArgTypes } from './shared/breadcrumb-arg-types.js';
 
 const meta: Meta<typeof BreadcrumbSimple> = {
-	title: 'Components/Breadcrumb/BreadcrumbSimple',
+	title: 'Composed Components/Breadcrumb/BreadcrumbSimple',
 	component: BreadcrumbSimple,
 	argTypes: breadcrumbSimpleArgTypes,
 	parameters: {

--- a/apps/docs/stories/breadcrumb.stories.tsx
+++ b/apps/docs/stories/breadcrumb.stories.tsx
@@ -16,7 +16,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { breadcrumbSimpleArgTypes } from './shared/breadcrumb-arg-types.js';
 
 const meta: Meta<typeof BreadcrumbSimple> = {
-	title: 'Components/Breadcrumb',
+	title: 'Composed Components/Breadcrumb',
 	component: BreadcrumbSimple,
 	argTypes: breadcrumbSimpleArgTypes,
 	parameters: {

--- a/apps/docs/stories/button-group.stories.tsx
+++ b/apps/docs/stories/button-group.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { COLORS, VARIANTS } from './shared/button-arg-types.js';
 
 const meta: Meta<typeof ButtonGroup> = {
-	title: 'Components/Button/ButtonGroup',
+	title: 'Primitive Components/Button/ButtonGroup',
 	component: ButtonGroup,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/button.stories.tsx
+++ b/apps/docs/stories/button.stories.tsx
@@ -5,7 +5,7 @@ import { fn } from 'storybook/test';
 import { buttonArgTypes, COLORS, VARIANTS } from './shared/button-arg-types.js';
 
 const meta: Meta<typeof Button> = {
-	title: 'Components/Button',
+	title: 'Primitive Components/Button',
 	component: Button,
 	decorators: [],
 	args: {

--- a/apps/docs/stories/calendar.stories.tsx
+++ b/apps/docs/stories/calendar.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof Calendar> = {
-	title: 'Components/Calendar',
+	title: 'Composed Components/Calendar',
 	component: Calendar,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/callout.stories.tsx
+++ b/apps/docs/stories/callout.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof Callout> = {
-	title: 'Components/Callout',
+	title: 'Primitive Components/Callout',
 	component: Callout,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/checkbox.stories.tsx
+++ b/apps/docs/stories/checkbox.stories.tsx
@@ -2,7 +2,7 @@ import { Checkbox } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Checkbox> = {
-	title: 'Components/Checkbox',
+	title: 'Primitive Components/Checkbox',
 	component: Checkbox,
 	argTypes: {
 		children: {

--- a/apps/docs/stories/combobox-command.stories.tsx
+++ b/apps/docs/stories/combobox-command.stories.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react';
 import { commandArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxCommand> = {
-	title: 'Components/Combobox/ComboboxCommand',
+	title: 'Primitive Components/Combobox/ComboboxCommand',
 	component: ComboboxCommand,
 	argTypes: {
 		...commandArgTypes,

--- a/apps/docs/stories/combobox-content.stories.tsx
+++ b/apps/docs/stories/combobox-content.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof ComboboxContent> = {
-	title: 'Components/Combobox/ComboboxContent',
+	title: 'Primitive Components/Combobox/ComboboxContent',
 	component: ComboboxContent,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/combobox-empty.stories.tsx
+++ b/apps/docs/stories/combobox-empty.stories.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react';
 import { emptyArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxEmpty> = {
-	title: 'Components/Combobox/ComboboxEmpty',
+	title: 'Primitive Components/Combobox/ComboboxEmpty',
 	component: ComboboxEmpty,
 	argTypes: emptyArgTypes,
 	parameters: {

--- a/apps/docs/stories/combobox-group.stories.tsx
+++ b/apps/docs/stories/combobox-group.stories.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import { groupArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxGroup> = {
-	title: 'Components/Combobox/ComboboxGroup',
+	title: 'Primitive Components/Combobox/ComboboxGroup',
 	component: ComboboxGroup,
 	argTypes: groupArgTypes,
 	parameters: {

--- a/apps/docs/stories/combobox-input.stories.tsx
+++ b/apps/docs/stories/combobox-input.stories.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react';
 import { inputArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxInput> = {
-	title: 'Components/Combobox/ComboboxInput',
+	title: 'Primitive Components/Combobox/ComboboxInput',
 	component: ComboboxInput,
 	argTypes: inputArgTypes,
 	parameters: {

--- a/apps/docs/stories/combobox-item.stories.tsx
+++ b/apps/docs/stories/combobox-item.stories.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react';
 import { itemArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxItem> = {
-	title: 'Components/Combobox/ComboboxItem',
+	title: 'Primitive Components/Combobox/ComboboxItem',
 	component: ComboboxItem,
 	argTypes: {
 		...itemArgTypes,

--- a/apps/docs/stories/combobox-list.stories.tsx
+++ b/apps/docs/stories/combobox-list.stories.tsx
@@ -14,7 +14,7 @@ import { useState } from 'react';
 import { listArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxList> = {
-	title: 'Components/Combobox/ComboboxList',
+	title: 'Primitive Components/Combobox/ComboboxList',
 	component: ComboboxList,
 	argTypes: listArgTypes,
 	parameters: {

--- a/apps/docs/stories/combobox-loading.stories.tsx
+++ b/apps/docs/stories/combobox-loading.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof ComboboxLoading> = {
-	title: 'Components/Combobox/ComboboxLoading',
+	title: 'Primitive Components/Combobox/ComboboxLoading',
 	component: ComboboxLoading,
 	argTypes: {
 		children: {

--- a/apps/docs/stories/combobox-primitive.stories.tsx
+++ b/apps/docs/stories/combobox-primitive.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof Combobox> = {
-	title: 'Components/Combobox/Combobox',
+	title: 'Primitive Components/Combobox/Combobox',
 	component: Combobox,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/combobox-separator.stories.tsx
+++ b/apps/docs/stories/combobox-separator.stories.tsx
@@ -16,7 +16,7 @@ import { useState } from 'react';
 import { separatorArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof ComboboxSeparator> = {
-	title: 'Components/Combobox/ComboboxSeparator',
+	title: 'Primitive Components/Combobox/ComboboxSeparator',
 	component: ComboboxSeparator,
 	argTypes: separatorArgTypes,
 	parameters: {

--- a/apps/docs/stories/combobox-simple.stories.tsx
+++ b/apps/docs/stories/combobox-simple.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof ComboboxSimple> = {
-	title: 'Components/Combobox/ComboboxSimple',
+	title: 'Composed Components/Combobox/ComboboxSimple',
 	component: ComboboxSimple,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/combobox-trigger.stories.tsx
+++ b/apps/docs/stories/combobox-trigger.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof ComboboxTrigger> = {
-	title: 'Components/Combobox/ComboboxTrigger',
+	title: 'Primitive Components/Combobox/ComboboxTrigger',
 	component: ComboboxTrigger,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/combobox.stories.tsx
+++ b/apps/docs/stories/combobox.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof ComboboxSimple> = {
-	title: 'Components/Combobox',
+	title: 'Composed Components/Combobox',
 	component: ComboboxSimple,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/command-dialog.stories.tsx
+++ b/apps/docs/stories/command-dialog.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof CommandDialog> = {
-	title: 'Components/Command/CommandDialog',
+	title: 'Primitive Components/Command/CommandDialog',
 	component: CommandDialog,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/command-empty.stories.tsx
+++ b/apps/docs/stories/command-empty.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { emptyArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandEmpty> = {
-	title: 'Components/Command/CommandEmpty',
+	title: 'Primitive Components/Command/CommandEmpty',
 	component: CommandEmpty,
 	argTypes: emptyArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-group.stories.tsx
+++ b/apps/docs/stories/command-group.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { groupArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandGroup> = {
-	title: 'Components/Command/CommandGroup',
+	title: 'Primitive Components/Command/CommandGroup',
 	component: CommandGroup,
 	argTypes: groupArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-input.stories.tsx
+++ b/apps/docs/stories/command-input.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { inputArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandInput> = {
-	title: 'Components/Command/CommandInput',
+	title: 'Primitive Components/Command/CommandInput',
 	component: CommandInput,
 	argTypes: inputArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-item.stories.tsx
+++ b/apps/docs/stories/command-item.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { itemArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandItem> = {
-	title: 'Components/Command/CommandItem',
+	title: 'Primitive Components/Command/CommandItem',
 	component: CommandItem,
 	argTypes: itemArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-list.stories.tsx
+++ b/apps/docs/stories/command-list.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { listArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandList> = {
-	title: 'Components/Command/CommandList',
+	title: 'Primitive Components/Command/CommandList',
 	component: CommandList,
 	argTypes: listArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-primitive.stories.tsx
+++ b/apps/docs/stories/command-primitive.stories.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { commandArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof Command> = {
-	title: 'Components/Command/Command',
+	title: 'Primitive Components/Command/Command',
 	component: Command,
 	argTypes: commandArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-separator.stories.tsx
+++ b/apps/docs/stories/command-separator.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { separatorArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandSeparator> = {
-	title: 'Components/Command/CommandSeparator',
+	title: 'Primitive Components/Command/CommandSeparator',
 	component: CommandSeparator,
 	argTypes: separatorArgTypes,
 	parameters: {

--- a/apps/docs/stories/command-shortcut.stories.tsx
+++ b/apps/docs/stories/command-shortcut.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { shortcutArgTypes } from './shared/command-combobox-arg-types.js';
 
 const meta: Meta<typeof CommandShortcut> = {
-	title: 'Components/Command/CommandShortcut',
+	title: 'Primitive Components/Command/CommandShortcut',
 	component: CommandShortcut,
 	argTypes: shortcutArgTypes,
 	parameters: {

--- a/apps/docs/stories/command.stories.tsx
+++ b/apps/docs/stories/command.stories.tsx
@@ -15,7 +15,7 @@ import { useState } from 'react';
 import { action } from 'storybook/actions';
 
 const meta: Meta<any> = {
-	title: 'Components/Command',
+	title: 'Primitive Components/Command',
 	component: Command,
 	parameters: {
 		controls: { expanded: true },

--- a/apps/docs/stories/confirm-dialog-url.stories.tsx
+++ b/apps/docs/stories/confirm-dialog-url.stories.tsx
@@ -5,7 +5,7 @@ import { NuqsAdapter } from 'nuqs/adapters/react';
 import { confirmUrlArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof ConfirmDialogUrl> = {
-	title: 'Components/Dialog/ConfirmDialogUrl',
+	title: 'Composed Components/Dialog/ConfirmDialogUrl',
 	component: ConfirmDialogUrl,
 	argTypes: confirmUrlArgTypes,
 	parameters: {

--- a/apps/docs/stories/confirm-dialog.stories.tsx
+++ b/apps/docs/stories/confirm-dialog.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { confirmArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof ConfirmDialog> = {
-	title: 'Components/Dialog/ConfirmDialog',
+	title: 'Composed Components/Dialog/ConfirmDialog',
 	component: ConfirmDialog,
 	argTypes: confirmArgTypes,
 	parameters: {

--- a/apps/docs/stories/confirm-drawer-url.stories.tsx
+++ b/apps/docs/stories/confirm-drawer-url.stories.tsx
@@ -7,7 +7,7 @@ import { confirmUrlArgTypes } from './shared/dialog-drawer-arg-types.js';
 const { position: _, ...sharedConfirmUrlArgTypes } = confirmUrlArgTypes ?? {};
 
 const meta: Meta<typeof ConfirmDrawerUrl> = {
-	title: 'Components/Drawer/ConfirmDrawerUrl',
+	title: 'Composed Components/Drawer/ConfirmDrawerUrl',
 	component: ConfirmDrawerUrl,
 	argTypes: {
 		...sharedConfirmUrlArgTypes,

--- a/apps/docs/stories/confirm-drawer.stories.tsx
+++ b/apps/docs/stories/confirm-drawer.stories.tsx
@@ -6,7 +6,7 @@ import { confirmArgTypes } from './shared/dialog-drawer-arg-types.js';
 const { position: _, ...sharedConfirmArgTypes } = confirmArgTypes ?? {};
 
 const meta: Meta<typeof ConfirmDrawer> = {
-	title: 'Components/Drawer/ConfirmDrawer',
+	title: 'Composed Components/Drawer/ConfirmDrawer',
 	component: ConfirmDrawer,
 	argTypes: {
 		...sharedConfirmArgTypes,

--- a/apps/docs/stories/data-table.stories.tsx
+++ b/apps/docs/stories/data-table.stories.tsx
@@ -1399,7 +1399,7 @@ export const VirtualizedInfiniteScrollDndResize: StoryObj<typeof DataTable<User>
 };
 
 const meta: Meta<typeof DataTable<User>> = {
-	title: 'Old Components/DataTable',
+	title: 'Composed Components/DataTable',
 	component: DataTable,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/date-picker.stories.tsx
+++ b/apps/docs/stories/date-picker.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof DatePicker> = {
-	title: 'Components/DatePicker',
+	title: 'Composed Components/DatePicker',
 	component: DatePicker,
 	tags: ['autodocs'],
 	argTypes: {

--- a/apps/docs/stories/dialog-close.stories.tsx
+++ b/apps/docs/stories/dialog-close.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { closeArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogClose> = {
-	title: 'Components/Dialog/DialogClose',
+	title: 'Primitive Components/Dialog/DialogClose',
 	component: DialogClose,
 	argTypes: closeArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-content.stories.tsx
+++ b/apps/docs/stories/dialog-content.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { contentArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogContent> = {
-	title: 'Components/Dialog/DialogContent',
+	title: 'Primitive Components/Dialog/DialogContent',
 	component: DialogContent,
 	argTypes: contentArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-description.stories.tsx
+++ b/apps/docs/stories/dialog-description.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { descriptionArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogDescription> = {
-	title: 'Components/Dialog/DialogDescription',
+	title: 'Primitive Components/Dialog/DialogDescription',
 	component: DialogDescription,
 	argTypes: descriptionArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-footer.stories.tsx
+++ b/apps/docs/stories/dialog-footer.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { footerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogFooter> = {
-	title: 'Components/Dialog/DialogFooter',
+	title: 'Primitive Components/Dialog/DialogFooter',
 	component: DialogFooter,
 	argTypes: footerArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-header.stories.tsx
+++ b/apps/docs/stories/dialog-header.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { headerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogHeader> = {
-	title: 'Components/Dialog/DialogHeader',
+	title: 'Primitive Components/Dialog/DialogHeader',
 	component: DialogHeader,
 	argTypes: headerArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-overlay.stories.tsx
+++ b/apps/docs/stories/dialog-overlay.stories.tsx
@@ -15,7 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { overlayComponentArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogOverlay> = {
-	title: 'Components/Dialog/DialogOverlay',
+	title: 'Primitive Components/Dialog/DialogOverlay',
 	component: DialogOverlay,
 	argTypes: overlayComponentArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-portal.stories.tsx
+++ b/apps/docs/stories/dialog-portal.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { portalArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogPortal> = {
-	title: 'Components/Dialog/DialogPortal',
+	title: 'Primitive Components/Dialog/DialogPortal',
 	component: DialogPortal,
 	argTypes: portalArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-primitive.stories.tsx
+++ b/apps/docs/stories/dialog-primitive.stories.tsx
@@ -16,7 +16,7 @@ import React from 'react';
 import { overlayArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof Dialog> = {
-	title: 'Components/Dialog/Dialog',
+	title: 'Primitive Components/Dialog/Dialog',
 	component: Dialog,
 	argTypes: overlayArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-subtitle.stories.tsx
+++ b/apps/docs/stories/dialog-subtitle.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { subtitleArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogSubtitle> = {
-	title: 'Components/Dialog/DialogSubtitle',
+	title: 'Primitive Components/Dialog/DialogSubtitle',
 	component: DialogSubtitle,
 	argTypes: subtitleArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-title.stories.tsx
+++ b/apps/docs/stories/dialog-title.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { titleArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogTitle> = {
-	title: 'Components/Dialog/DialogTitle',
+	title: 'Primitive Components/Dialog/DialogTitle',
 	component: DialogTitle,
 	argTypes: titleArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-trigger.stories.tsx
+++ b/apps/docs/stories/dialog-trigger.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { triggerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogTrigger> = {
-	title: 'Components/Dialog/DialogTrigger',
+	title: 'Primitive Components/Dialog/DialogTrigger',
 	component: DialogTrigger,
 	argTypes: triggerArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-wrapper.stories.tsx
+++ b/apps/docs/stories/dialog-wrapper.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wrapperArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogWrapper> = {
-	title: 'Components/Dialog/DialogWrapper',
+	title: 'Composed Components/Dialog/DialogWrapper',
 	component: DialogWrapper,
 	argTypes: wrapperArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog.stories.tsx
+++ b/apps/docs/stories/dialog.stories.tsx
@@ -19,7 +19,7 @@ import React from 'react';
 import { overlayArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof Dialog> = {
-	title: 'Components/Dialog',
+	title: 'Primitive Components/Dialog',
 	component: Dialog,
 	argTypes: overlayArgTypes,
 	parameters: {

--- a/apps/docs/stories/divider.stories.tsx
+++ b/apps/docs/stories/divider.stories.tsx
@@ -2,7 +2,7 @@ import { Divider } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Divider> = {
-	title: 'Components/Divider',
+	title: 'Primitive Components/Divider',
 	component: Divider,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/drawer-close.stories.tsx
+++ b/apps/docs/stories/drawer-close.stories.tsx
@@ -15,7 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { closeArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerClose> = {
-	title: 'Components/Drawer/DrawerClose',
+	title: 'Primitive Components/Drawer/DrawerClose',
 	component: DrawerClose,
 	argTypes: closeArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-content.stories.tsx
+++ b/apps/docs/stories/drawer-content.stories.tsx
@@ -16,7 +16,7 @@ import { contentArgTypes } from './shared/dialog-drawer-arg-types.js';
 const { position: _, ...sharedContentArgTypes } = contentArgTypes ?? {};
 
 const meta: Meta<typeof DrawerContent> = {
-	title: 'Components/Drawer/DrawerContent',
+	title: 'Primitive Components/Drawer/DrawerContent',
 	component: DrawerContent,
 	argTypes: {
 		...sharedContentArgTypes,

--- a/apps/docs/stories/drawer-description.stories.tsx
+++ b/apps/docs/stories/drawer-description.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { descriptionArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerDescription> = {
-	title: 'Components/Drawer/DrawerDescription',
+	title: 'Primitive Components/Drawer/DrawerDescription',
 	component: DrawerDescription,
 	argTypes: descriptionArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-footer.stories.tsx
+++ b/apps/docs/stories/drawer-footer.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { footerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerFooter> = {
-	title: 'Components/Drawer/DrawerFooter',
+	title: 'Primitive Components/Drawer/DrawerFooter',
 	component: DrawerFooter,
 	argTypes: footerArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-header.stories.tsx
+++ b/apps/docs/stories/drawer-header.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { headerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerHeader> = {
-	title: 'Components/Drawer/DrawerHeader',
+	title: 'Primitive Components/Drawer/DrawerHeader',
 	component: DrawerHeader,
 	argTypes: headerArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-overlay.stories.tsx
+++ b/apps/docs/stories/drawer-overlay.stories.tsx
@@ -15,7 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { overlayComponentArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerOverlay> = {
-	title: 'Components/Drawer/DrawerOverlay',
+	title: 'Primitive Components/Drawer/DrawerOverlay',
 	component: DrawerOverlay,
 	argTypes: overlayComponentArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-portal.stories.tsx
+++ b/apps/docs/stories/drawer-portal.stories.tsx
@@ -15,7 +15,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { portalArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerPortal> = {
-	title: 'Components/Drawer/DrawerPortal',
+	title: 'Primitive Components/Drawer/DrawerPortal',
 	component: DrawerPortal,
 	argTypes: portalArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-subtitle.stories.tsx
+++ b/apps/docs/stories/drawer-subtitle.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { subtitleArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerSubtitle> = {
-	title: 'Components/Drawer/DrawerSubtitle',
+	title: 'Primitive Components/Drawer/DrawerSubtitle',
 	component: DrawerSubtitle,
 	argTypes: subtitleArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-title.stories.tsx
+++ b/apps/docs/stories/drawer-title.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { titleArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerTitle> = {
-	title: 'Components/Drawer/DrawerTitle',
+	title: 'Primitive Components/Drawer/DrawerTitle',
 	component: DrawerTitle,
 	argTypes: titleArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-trigger.stories.tsx
+++ b/apps/docs/stories/drawer-trigger.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { triggerArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DrawerTrigger> = {
-	title: 'Components/Drawer/DrawerTrigger',
+	title: 'Primitive Components/Drawer/DrawerTrigger',
 	component: DrawerTrigger,
 	argTypes: triggerArgTypes,
 	parameters: {

--- a/apps/docs/stories/drawer-wrapper.stories.tsx
+++ b/apps/docs/stories/drawer-wrapper.stories.tsx
@@ -6,7 +6,7 @@ import { wrapperArgTypes } from './shared/dialog-drawer-arg-types.js';
 const { width, titleIcon, ...sharedWrapperArgTypes } = wrapperArgTypes ?? {};
 
 const meta: Meta<typeof DrawerWrapper> = {
-	title: 'Components/Drawer/DrawerWrapper',
+	title: 'Composed Components/Drawer/DrawerWrapper',
 	component: DrawerWrapper,
 	argTypes: {
 		...sharedWrapperArgTypes,

--- a/apps/docs/stories/drawer.stories.tsx
+++ b/apps/docs/stories/drawer.stories.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 import { overlayArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof Drawer> = {
-	title: 'Components/Drawer',
+	title: 'Primitive Components/Drawer',
 	component: Drawer,
 	argTypes: overlayArgTypes,
 	parameters: {

--- a/apps/docs/stories/dropdown-menu-back.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-back.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuBack> = {
-	title: 'Components/DropdownMenu/DropdownMenuBack',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuBack',
 	component: DropdownMenuBack,
 	argTypes: {
 		label: {

--- a/apps/docs/stories/dropdown-menu-checkbox-item.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-checkbox-item.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuCheckboxItem> = {
-	title: 'Components/DropdownMenu/DropdownMenuCheckboxItem',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuCheckboxItem',
 	component: DropdownMenuCheckboxItem,
 	argTypes: {
 		checked: {

--- a/apps/docs/stories/dropdown-menu-content.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-content.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuContent> = {
-	title: 'Components/DropdownMenu/DropdownMenuContent',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuContent',
 	component: DropdownMenuContent,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/dropdown-menu-group.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-group.stories.tsx
@@ -11,7 +11,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuGroup> = {
-	title: 'Components/DropdownMenu/DropdownMenuGroup',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuGroup',
 	component: DropdownMenuGroup,
 	argTypes: {
 		children: {

--- a/apps/docs/stories/dropdown-menu-item.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-item.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuItem> = {
-	title: 'Components/DropdownMenu/DropdownMenuItem',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuItem',
 	component: DropdownMenuItem,
 	argTypes: {
 		inset: {

--- a/apps/docs/stories/dropdown-menu-label.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-label.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuLabel> = {
-	title: 'Components/DropdownMenu/DropdownMenuLabel',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuLabel',
 	component: DropdownMenuLabel,
 	argTypes: {
 		inset: {

--- a/apps/docs/stories/dropdown-menu-loading.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-loading.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuLoading> = {
-	title: 'Components/DropdownMenu/DropdownMenuLoading',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuLoading',
 	component: DropdownMenuLoading,
 	argTypes: {
 		text: {

--- a/apps/docs/stories/dropdown-menu-multi-step.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-multi-step.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuMultiStep> = {
-	title: 'Components/DropdownMenu/DropdownMenuMultiStep',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuMultiStep',
 	component: DropdownMenuMultiStep,
 	argTypes: {
 		defaultOpen: {

--- a/apps/docs/stories/dropdown-menu-portal.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-portal.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuPortal> = {
-	title: 'Components/DropdownMenu/DropdownMenuPortal',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuPortal',
 	component: DropdownMenuPortal,
 	argTypes: {
 		container: {

--- a/apps/docs/stories/dropdown-menu-radio-group.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-radio-group.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuRadioGroup> = {
-	title: 'Components/DropdownMenu/DropdownMenuRadioGroup',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuRadioGroup',
 	component: DropdownMenuRadioGroup,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/dropdown-menu-radio-item.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-radio-item.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuRadioItem> = {
-	title: 'Components/DropdownMenu/DropdownMenuRadioItem',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuRadioItem',
 	component: DropdownMenuRadioItem,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/dropdown-menu-root.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-root.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenu> = {
-	title: 'Components/DropdownMenu/DropdownMenu',
+	title: 'Primitive Components/DropdownMenu/DropdownMenu',
 	component: DropdownMenu,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/dropdown-menu-search.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-search.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo, useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuSearch> = {
-	title: 'Components/DropdownMenu/DropdownMenuSearch',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuSearch',
 	component: DropdownMenuSearch,
 	argTypes: {
 		placeholder: {

--- a/apps/docs/stories/dropdown-menu-separator.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-separator.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuSeparator> = {
-	title: 'Components/DropdownMenu/DropdownMenuSeparator',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuSeparator',
 	component: DropdownMenuSeparator,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/dropdown-menu-shortcut.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-shortcut.stories.tsx
@@ -9,7 +9,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuShortcut> = {
-	title: 'Components/DropdownMenu/DropdownMenuShortcut',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuShortcut',
 	component: DropdownMenuShortcut,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/dropdown-menu-sub-content.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-sub-content.stories.tsx
@@ -11,7 +11,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuSubContent> = {
-	title: 'Components/DropdownMenu/DropdownMenuSubContent',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuSubContent',
 	component: DropdownMenuSubContent,
 	argTypes: {
 		sideOffset: {

--- a/apps/docs/stories/dropdown-menu-sub-trigger.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-sub-trigger.stories.tsx
@@ -12,7 +12,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuSubTrigger> = {
-	title: 'Components/DropdownMenu/DropdownMenuSubTrigger',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuSubTrigger',
 	component: DropdownMenuSubTrigger,
 	argTypes: {
 		inset: {

--- a/apps/docs/stories/dropdown-menu-sub.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-sub.stories.tsx
@@ -38,7 +38,7 @@ function SubMenuFrame({
 }
 
 const meta: Meta<typeof DropdownMenuSub> = {
-	title: 'Components/DropdownMenu/DropdownMenuSub',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuSub',
 	component: DropdownMenuSub,
 	argTypes: {
 		defaultOpen: {

--- a/apps/docs/stories/dropdown-menu-trigger.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-trigger.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof DropdownMenuTrigger> = {
-	title: 'Components/DropdownMenu/DropdownMenuTrigger',
+	title: 'Primitive Components/DropdownMenu/DropdownMenuTrigger',
 	component: DropdownMenuTrigger,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/dropdown-menu.stories.tsx
+++ b/apps/docs/stories/dropdown-menu.stories.tsx
@@ -18,7 +18,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo, useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuSimple> = {
-	title: 'Components/DropdownMenu',
+	title: 'Composed Components/DropdownMenu/DropdownMenuSimple',
 	component: DropdownMenuSimple,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/input-number.stories.tsx
+++ b/apps/docs/stories/input-number.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof InputNumber> = {
-	title: 'Components/InputNumber',
+	title: 'Primitive Components/InputNumber',
 	component: InputNumber,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/input.stories.tsx
+++ b/apps/docs/stories/input.stories.tsx
@@ -2,7 +2,7 @@ import { Input } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Input> = {
-	title: 'Components/Input',
+	title: 'Primitive Components/Input',
 	component: Input,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/kbd.stories.tsx
+++ b/apps/docs/stories/kbd.stories.tsx
@@ -2,7 +2,7 @@ import { Kbd } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Kbd> = {
-	title: 'Components/Kbd',
+	title: 'Primitive Components/Kbd',
 	component: Kbd,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/pagination-container.stories.tsx
+++ b/apps/docs/stories/pagination-container.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof PaginationContainer> = {
-	title: 'Components/Pagination/PaginationContainer',
+	title: 'Primitive Components/Pagination/PaginationContainer',
 	component: PaginationContainer,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/pagination-content.stories.tsx
+++ b/apps/docs/stories/pagination-content.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof PaginationContent> = {
-	title: 'Components/Pagination/PaginationContent',
+	title: 'Primitive Components/Pagination/PaginationContent',
 	component: PaginationContent,
 	argTypes: {
 		id: {

--- a/apps/docs/stories/pagination-ellipsis.stories.tsx
+++ b/apps/docs/stories/pagination-ellipsis.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof PaginationEllipsis> = {
-	title: 'Components/Pagination/PaginationEllipsis',
+	title: 'Primitive Components/Pagination/PaginationEllipsis',
 	component: PaginationEllipsis,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/pagination-item.stories.tsx
+++ b/apps/docs/stories/pagination-item.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof PaginationItem> = {
-	title: 'Components/Pagination/PaginationItem',
+	title: 'Primitive Components/Pagination/PaginationItem',
 	component: PaginationItem,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/pagination-link.stories.tsx
+++ b/apps/docs/stories/pagination-link.stories.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 import { buttonArgTypes } from './shared/button-arg-types.js';
 
 const meta: Meta<typeof PaginationLink> = {
-	title: 'Components/Pagination/PaginationLink',
+	title: 'Primitive Components/Pagination/PaginationLink',
 	component: PaginationLink,
 	argTypes: {
 		isActive: {

--- a/apps/docs/stories/pagination-next.stories.tsx
+++ b/apps/docs/stories/pagination-next.stories.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 import { buttonArgTypes } from './shared/button-arg-types.js';
 
 const meta: Meta<typeof PaginationNext> = {
-	title: 'Components/Pagination/PaginationNext',
+	title: 'Primitive Components/Pagination/PaginationNext',
 	component: PaginationNext,
 	argTypes: buttonArgTypes,
 	parameters: {

--- a/apps/docs/stories/pagination-previous.stories.tsx
+++ b/apps/docs/stories/pagination-previous.stories.tsx
@@ -11,7 +11,7 @@ import { useState } from 'react';
 import { buttonArgTypes } from './shared/button-arg-types.js';
 
 const meta: Meta<typeof PaginationPrevious> = {
-	title: 'Components/Pagination/PaginationPrevious',
+	title: 'Primitive Components/Pagination/PaginationPrevious',
 	component: PaginationPrevious,
 	argTypes: buttonArgTypes,
 	parameters: {

--- a/apps/docs/stories/pagination-url.stories.tsx
+++ b/apps/docs/stories/pagination-url.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NuqsAdapter } from 'nuqs/adapters/react';
 
 const meta: Meta<typeof PaginationUrl> = {
-	title: 'Components/Pagination/PaginationUrl',
+	title: 'Composed Components/Pagination/PaginationUrl',
 	component: PaginationUrl,
 	argTypes: {
 		urlKey: {

--- a/apps/docs/stories/pagination.stories.tsx
+++ b/apps/docs/stories/pagination.stories.tsx
@@ -20,7 +20,7 @@ const ControlledPagination = (args: PaginationProps, initialPage: number): JSX.E
 };
 
 const meta: Meta<typeof Pagination> = {
-	title: 'Components/Pagination/Pagination',
+	title: 'Composed Components/Pagination/Pagination',
 	component: Pagination,
 	argTypes: {
 		total: {

--- a/apps/docs/stories/persisted-announcement-banner.stories.tsx
+++ b/apps/docs/stories/persisted-announcement-banner.stories.tsx
@@ -2,7 +2,7 @@ import { PersistedAnnouncementBanner } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof PersistedAnnouncementBanner> = {
-	title: 'Components/AnnouncementBanner/PersistedAnnouncementBanner',
+	title: 'Composed Components/AnnouncementBanner/PersistedAnnouncementBanner',
 	component: PersistedAnnouncementBanner,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/pin-list.stories.tsx
+++ b/apps/docs/stories/pin-list.stories.tsx
@@ -29,7 +29,7 @@ const createPinListItem = (
 });
 
 const meta: Meta<typeof PinList> = {
-	title: 'Components/PinList',
+	title: 'Composed Components/PinList',
 	component: PinList,
 	argTypes: {
 		items: {

--- a/apps/docs/stories/popover-anchor.stories.tsx
+++ b/apps/docs/stories/popover-anchor.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { anchorArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof PopoverAnchor> = {
-	title: 'Components/Popover/PopoverAnchor',
+	title: 'Primitive Components/Popover/PopoverAnchor',
 	component: PopoverAnchor,
 	argTypes: anchorArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover-content.stories.tsx
+++ b/apps/docs/stories/popover-content.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { contentArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof PopoverContent> = {
-	title: 'Components/Popover/PopoverContent',
+	title: 'Primitive Components/Popover/PopoverContent',
 	component: PopoverContent,
 	argTypes: contentArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover-primitive.stories.tsx
+++ b/apps/docs/stories/popover-primitive.stories.tsx
@@ -12,7 +12,7 @@ import React from 'react';
 import { popoverArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof Popover> = {
-	title: 'Components/Popover/Popover',
+	title: 'Primitive Components/Popover/Popover',
 	component: Popover,
 	argTypes: popoverArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover-simple.stories.tsx
+++ b/apps/docs/stories/popover-simple.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { simpleArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof PopoverSimple> = {
-	title: 'Components/Popover/PopoverSimple',
+	title: 'Composed Components/Popover/PopoverSimple',
 	component: PopoverSimple,
 	argTypes: simpleArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover-trigger.stories.tsx
+++ b/apps/docs/stories/popover-trigger.stories.tsx
@@ -10,7 +10,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { triggerArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof PopoverTrigger> = {
-	title: 'Components/Popover/PopoverTrigger',
+	title: 'Primitive Components/Popover/PopoverTrigger',
 	component: PopoverTrigger,
 	argTypes: triggerArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover.stories.tsx
+++ b/apps/docs/stories/popover.stories.tsx
@@ -17,7 +17,7 @@ const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
 const meta: Meta<typeof Popover> = {
-	title: 'Components/Popover',
+	title: 'Primitive Components/Popover',
 	component: Popover,
 	argTypes: popoverArgTypes,
 	parameters: {

--- a/apps/docs/stories/progress.stories.tsx
+++ b/apps/docs/stories/progress.stories.tsx
@@ -2,7 +2,7 @@ import { Progress, type ProgressProps } from '@signozhq/ui';
 import type { Meta, StoryFn } from '@storybook/react-vite';
 
 const meta: Meta<typeof Progress> = {
-	title: 'Components/Progress',
+	title: 'Primitive Components/Progress',
 	component: Progress,
 	argTypes: {
 		percent: {

--- a/apps/docs/stories/radio-group-item.stories.tsx
+++ b/apps/docs/stories/radio-group-item.stories.tsx
@@ -2,7 +2,7 @@ import { RadioGroup, RadioGroupItem } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof RadioGroupItem> = {
-	title: 'Components/RadioGroup/RadioGroupItem',
+	title: 'Primitive Components/RadioGroup/RadioGroupItem',
 	component: RadioGroupItem,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/radio-group-label.stories.tsx
+++ b/apps/docs/stories/radio-group-label.stories.tsx
@@ -2,7 +2,7 @@ import { RadioGroup, RadioGroupItem, RadioGroupLabel } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof RadioGroupLabel> = {
-	title: 'Components/RadioGroup/RadioGroupLabel',
+	title: 'Primitive Components/RadioGroup/RadioGroupLabel',
 	component: RadioGroupLabel,
 	argTypes: {
 		htmlFor: {

--- a/apps/docs/stories/radio-group.stories.tsx
+++ b/apps/docs/stories/radio-group.stories.tsx
@@ -5,7 +5,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import * as RadioGroupItemStories from './radio-group-item.stories.js';
 
 const meta: Meta<typeof RadioGroup> = {
-	title: 'Components/RadioGroup',
+	title: 'Primitive Components/RadioGroup',
 	component: RadioGroup,
 	subcomponents: {
 		RadioGroupItem: RadioGroupItem as any,

--- a/apps/docs/stories/resizable-handle.stories.tsx
+++ b/apps/docs/stories/resizable-handle.stories.tsx
@@ -2,7 +2,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@signozhq/
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ResizableHandle> = {
-	title: 'Components/Resizable/ResizableHandle',
+	title: 'Primitive Components/Resizable/ResizableHandle',
 	component: ResizableHandle,
 	argTypes: {
 		withHandle: {

--- a/apps/docs/stories/resizable-panel.stories.tsx
+++ b/apps/docs/stories/resizable-panel.stories.tsx
@@ -3,7 +3,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@signozhq/
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ResizablePanel> = {
-	title: 'Components/Resizable/ResizablePanel',
+	title: 'Primitive Components/Resizable/ResizablePanel',
 	component: ResizablePanel,
 	argTypes: {
 		defaultSize: {

--- a/apps/docs/stories/resizable.stories.tsx
+++ b/apps/docs/stories/resizable.stories.tsx
@@ -8,7 +8,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ResizablePanelGroup> = {
-	title: 'Components/Resizable',
+	title: 'Primitive Components/Resizable',
 	component: ResizablePanelGroup,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/select-arrow.stories.tsx
+++ b/apps/docs/stories/select-arrow.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectArrow> = {
-	title: 'Components/Select/SelectArrow',
+	title: 'Primitive Components/Select/SelectArrow',
 	component: SelectArrow,
 	argTypes: {
 		width: {

--- a/apps/docs/stories/select-content.stories.tsx
+++ b/apps/docs/stories/select-content.stories.tsx
@@ -12,7 +12,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectContent> = {
-	title: 'Components/Select/SelectContent',
+	title: 'Primitive Components/Select/SelectContent',
 	component: SelectContent,
 	argTypes: {
 		position: {

--- a/apps/docs/stories/select-group.stories.tsx
+++ b/apps/docs/stories/select-group.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectGroup> = {
-	title: 'Components/Select/SelectGroup',
+	title: 'Primitive Components/Select/SelectGroup',
 	component: SelectGroup,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/select-icon.stories.tsx
+++ b/apps/docs/stories/select-icon.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectIcon> = {
-	title: 'Components/Select/SelectIcon',
+	title: 'Primitive Components/Select/SelectIcon',
 	component: SelectIcon,
 	argTypes: {
 		asChild: {

--- a/apps/docs/stories/select-item.stories.tsx
+++ b/apps/docs/stories/select-item.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectItem> = {
-	title: 'Components/Select/SelectItem',
+	title: 'Primitive Components/Select/SelectItem',
 	component: SelectItem,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/select-loading.stories.tsx
+++ b/apps/docs/stories/select-loading.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof SelectLoading> = {
-	title: 'Components/Select/SelectLoading',
+	title: 'Primitive Components/Select/SelectLoading',
 	component: SelectLoading,
 	argTypes: {
 		children: {

--- a/apps/docs/stories/select-portal.stories.tsx
+++ b/apps/docs/stories/select-portal.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectPortal> = {
-	title: 'Components/Select/SelectPortal',
+	title: 'Primitive Components/Select/SelectPortal',
 	component: SelectPortal,
 	argTypes: {
 		container: {

--- a/apps/docs/stories/select-scroll-buttons.stories.tsx
+++ b/apps/docs/stories/select-scroll-buttons.stories.tsx
@@ -11,7 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta = {
-	title: 'Components/Select/SelectScrollButtons',
+	title: 'Primitive Components/Select/SelectScrollButtons',
 	parameters: {
 		layout: 'fullscreen',
 	},

--- a/apps/docs/stories/select-simple.stories.tsx
+++ b/apps/docs/stories/select-simple.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectSimple> = {
-	title: 'Components/Select/SelectSimple',
+	title: 'Composed Components/Select/SelectSimple',
 	component: SelectSimple,
 	argTypes: {
 		items: {

--- a/apps/docs/stories/select-trigger.stories.tsx
+++ b/apps/docs/stories/select-trigger.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectTrigger> = {
-	title: 'Components/Select/SelectTrigger',
+	title: 'Primitive Components/Select/SelectTrigger',
 	component: SelectTrigger,
 	argTypes: {
 		placeholder: {

--- a/apps/docs/stories/select-viewport.stories.tsx
+++ b/apps/docs/stories/select-viewport.stories.tsx
@@ -14,7 +14,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 
 const meta: Meta<typeof SelectViewport> = {
-	title: 'Components/Select/SelectViewport',
+	title: 'Primitive Components/Select/SelectViewport',
 	component: SelectViewport,
 	argTypes: {
 		className: {

--- a/apps/docs/stories/select.stories.tsx
+++ b/apps/docs/stories/select.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof Select> = {
-	title: 'Components/Select',
+	title: 'Primitive Components/Select',
 	component: Select,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/skeleton.stories.tsx
+++ b/apps/docs/stories/skeleton.stories.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Skeleton> = {
-	title: 'Components/Skeleton',
+	title: 'Primitive Components/Skeleton',
 	component: Skeleton,
 	argTypes: {
 		active: {
@@ -38,7 +38,6 @@ export const Default: Story = {
 export const Overview: Story = {
 	render: () => (
 		<div style={{ display: 'flex', flexDirection: 'column', gap: '2rem', padding: '1rem' }}>
-
 			{/* Base variants */}
 			<div>
 				<p style={{ marginBottom: '0.5rem', fontWeight: 600 }}>Base — with title & paragraph</p>
@@ -104,7 +103,6 @@ export const Overview: Story = {
 					</div>
 				</div>
 			</div>
-
 		</div>
 	),
 };

--- a/apps/docs/stories/slider.stories.tsx
+++ b/apps/docs/stories/slider.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof Slider> = {
-	title: 'Components/Slider',
+	title: 'Primitive Components/Slider',
 	component: Slider,
 	parameters: {
 		layout: 'centered',

--- a/apps/docs/stories/sonner.stories.tsx
+++ b/apps/docs/stories/sonner.stories.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonColor, Toaster, toast } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Toaster> = {
-	title: 'Components/Sonner',
+	title: 'Primitive Components/Sonner',
 	component: Toaster,
 };
 

--- a/apps/docs/stories/switch.stories.tsx
+++ b/apps/docs/stories/switch.stories.tsx
@@ -2,7 +2,7 @@ import { Switch } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Switch> = {
-	title: 'Components/Switch',
+	title: 'Primitive Components/Switch',
 	component: Switch,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/table.stories.tsx
+++ b/apps/docs/stories/table.stories.tsx
@@ -77,7 +77,7 @@ const users = [
 ];
 
 const meta: Meta<typeof Table> = {
-	title: 'Primitive Components/Table',
+	title: 'Old Components/Basic Table',
 	component: Table,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/table.stories.tsx
+++ b/apps/docs/stories/table.stories.tsx
@@ -77,7 +77,7 @@ const users = [
 ];
 
 const meta: Meta<typeof Table> = {
-	title: 'Old Components/Basic Table',
+	title: 'Primitive Components/Table',
 	component: Table,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/tabs-content.stories.tsx
+++ b/apps/docs/stories/tabs-content.stories.tsx
@@ -2,7 +2,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TabsContent> = {
-	title: 'Components/Tabs/TabsContent',
+	title: 'Primitive Components/Tabs/TabsContent',
 	component: TabsContent,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/tabs-list.stories.tsx
+++ b/apps/docs/stories/tabs-list.stories.tsx
@@ -2,7 +2,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TabsList> = {
-	title: 'Components/Tabs/TabsList',
+	title: 'Primitive Components/Tabs/TabsList',
 	component: TabsList,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/tabs-root.stories.tsx
+++ b/apps/docs/stories/tabs-root.stories.tsx
@@ -3,7 +3,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TabsRoot> = {
-	title: 'Components/Tabs/TabsRoot',
+	title: 'Primitive Components/Tabs/TabsRoot',
 	component: TabsRoot,
 	argTypes: {
 		defaultValue: {

--- a/apps/docs/stories/tabs-trigger.stories.tsx
+++ b/apps/docs/stories/tabs-trigger.stories.tsx
@@ -2,7 +2,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TabsTrigger> = {
-	title: 'Components/Tabs/TabsTrigger',
+	title: 'Primitive Components/Tabs/TabsTrigger',
 	component: TabsTrigger,
 	argTypes: {
 		testId: {

--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -14,7 +14,7 @@ import { type TabItemProps, Tabs, type TabVariants } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Tabs> = {
-	title: 'Components/Tabs',
+	title: 'Composed Components/Tabs/TabsSimple',
 	component: Tabs,
 	argTypes: {
 		items: {

--- a/apps/docs/stories/text-ellipsis.stories.tsx
+++ b/apps/docs/stories/text-ellipsis.stories.tsx
@@ -2,7 +2,7 @@ import { TextEllipsis, useTextEllipsisWidth } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TextEllipsis> = {
-	title: 'Components/TextEllipsis',
+	title: 'Primitive Components/TextEllipsis',
 	component: TextEllipsis,
 	parameters: {
 		layout: 'fullscreen',

--- a/apps/docs/stories/toggle-group-item.stories.tsx
+++ b/apps/docs/stories/toggle-group-item.stories.tsx
@@ -3,7 +3,7 @@ import { ToggleGroup, ToggleGroupItem } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ToggleGroupItem> = {
-	title: 'Components/ToggleGroup/ToggleGroupItem',
+	title: 'Primitive Components/ToggleGroup/ToggleGroupItem',
 	component: ToggleGroupItem,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/toggle-group-simple.stories.tsx
+++ b/apps/docs/stories/toggle-group-simple.stories.tsx
@@ -3,7 +3,7 @@ import { ToggleGroupSimple, type ToggleGroupSimpleItem } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ToggleGroupSimple> = {
-	title: 'Components/ToggleGroup/ToggleGroupSimple',
+	title: 'Composed Components/ToggleGroup/ToggleGroupSimple',
 	component: ToggleGroupSimple,
 	argTypes: {
 		type: {

--- a/apps/docs/stories/toggle-group.stories.tsx
+++ b/apps/docs/stories/toggle-group.stories.tsx
@@ -12,7 +12,7 @@ import { ToggleGroup, ToggleGroupItem } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ToggleGroup> = {
-	title: 'Components/ToggleGroup',
+	title: 'Primitive Components/ToggleGroup',
 	component: ToggleGroup,
 	subcomponents: {
 		ToggleGroupItem: ToggleGroupItem as React.ComponentType<unknown>,

--- a/apps/docs/stories/toggle.stories.tsx
+++ b/apps/docs/stories/toggle.stories.tsx
@@ -3,7 +3,7 @@ import { Toggle, type ToggleColor } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Toggle> = {
-	title: 'Components/Toggle',
+	title: 'Primitive Components/Toggle',
 	component: Toggle,
 	argTypes: {
 		value: {

--- a/apps/docs/stories/tooltip-content.stories.tsx
+++ b/apps/docs/stories/tooltip-content.stories.tsx
@@ -11,7 +11,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TooltipContent> = {
-	title: 'Components/Tooltip/TooltipContent',
+	title: 'Primitive Components/Tooltip/TooltipContent',
 	component: TooltipContent,
 	argTypes: {
 		side: {

--- a/apps/docs/stories/tooltip-provider.stories.tsx
+++ b/apps/docs/stories/tooltip-provider.stories.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonColor, ButtonVariant, TooltipProvider, TooltipSimple } fr
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TooltipProvider> = {
-	title: 'Components/Tooltip/TooltipProvider',
+	title: 'Primitive Components/Tooltip/TooltipProvider',
 	component: TooltipProvider,
 	argTypes: {
 		delayDuration: {

--- a/apps/docs/stories/tooltip-simple.stories.tsx
+++ b/apps/docs/stories/tooltip-simple.stories.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonColor, ButtonVariant, TooltipProvider, TooltipSimple } fr
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TooltipSimple> = {
-	title: 'Components/Tooltip/TooltipSimple',
+	title: 'Composed Components/Tooltip/TooltipSimple',
 	component: TooltipSimple,
 	argTypes: {
 		title: {

--- a/apps/docs/stories/tooltip-trigger.stories.tsx
+++ b/apps/docs/stories/tooltip-trigger.stories.tsx
@@ -10,7 +10,7 @@ import {
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TooltipTrigger> = {
-	title: 'Components/Tooltip/TooltipTrigger',
+	title: 'Primitive Components/Tooltip/TooltipTrigger',
 	component: TooltipTrigger,
 	argTypes: {
 		asChild: {

--- a/apps/docs/stories/tooltip.stories.tsx
+++ b/apps/docs/stories/tooltip.stories.tsx
@@ -14,7 +14,7 @@ const SIDES = ['top', 'right', 'bottom', 'left'] as const;
 const ALIGNS = ['start', 'center', 'end'] as const;
 
 const meta: Meta<typeof TooltipRoot> = {
-	title: 'Components/Tooltip',
+	title: 'Primitive Components/Tooltip',
 	component: TooltipRoot,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/typography.stories.tsx
+++ b/apps/docs/stories/typography.stories.tsx
@@ -50,7 +50,7 @@ const FontWeightShowcase: React.FC = () => (
 );
 
 export default {
-	title: 'Components/Typography',
+	title: 'Primitive Components/Typography',
 	component: Typography,
 	parameters: {
 		layout: 'fullscreen',


### PR DESCRIPTION
 ---                                                                                                 
  Title: docs(storybook): split stories into Primitive and Composed Components                          
                                                                                                        
  Body:                                                                                                 
                                                                                                        
  Closes #225                                                                                           
                                                                                                      
  ## What's changed           
                                                                                                        
  Reorganises the Storybook sidebar by splitting all stories into two clear sections:
                                                                                                        
  - **Primitive Components** — base building blocks with no built-in composition logic (Button, Badge,
  Input, Dialog sub-parts, Combobox sub-parts, etc.)                                                    
  - **Composed Components** — components with built-in functionality or opinionated presets           
  (ComboboxSimple, SelectSimple, ConfirmDialog, DialogWrapper, Calendar, DataTable, DatePicker, etc.)   
                                                                                                      
  Removes the old `Components` and `Old Components` sidebar sections entirely.                          
                                                                                                        
  ## Changes                  
                                                                                                        
  - Updated `storySort` order in `preview.tsx`: `Intro → Design System → Primitive Components → Composed
   Components`                                                                                          
  - Updated `title` in all 155 story files to reflect the new categories                              
                                                                                                        
  ## Evidence                                                                                       
                                                                                                        
  
<img width="1470" height="877" alt="Screenshot 2026-06-03 at 12 06 28 AM" src="https://github.com/user-attachments/assets/22d9985b-11b1-48aa-ae84-822720b0b778" />


  ## Notes                                                                                            
                                                                                                        
  - Pre-existing TypeScript error in `select-item.stories.tsx:71` (`value` specified twice) — not       
  introduced b
