### PR TITLE
fix: added isloading

### DIFF
--- a/apps/docs/stories/switch.stories.tsx
+++ b/apps/docs/stories/switch.stories.tsx
@@ -67,6 +67,11 @@ const meta: Meta<typeof Switch> = {
 			description: 'Additional CSS classes to apply to the switch.',
 			table: { category: 'Styling', type: { summary: 'string' } },
 		},
+		isLoading: {
+			control: 'boolean',
+			description: 'When true, shows a loading spinner in the thumb and prevents user interaction.',
+			table: { category: 'Behavior', defaultValue: { summary: 'false' } },
+		},
 		onChange: {
 			control: false,
 			description: 'The callback invoked when the checked state of the switch changes.',
@@ -99,6 +104,15 @@ export const Default: Story = {
 	},
 };
 
+export const IsLoading: Story = {
+	args: {
+		id: 'loading',
+		children: 'Loading switch',
+		isLoading: true,
+		color: 'robin',
+	},
+};
+
 export const AllVariants: Story = {
 	render: () => (
 		<div className="space-y-4">
@@ -127,6 +141,19 @@ export const AllVariants: Story = {
 						color={c as any}
 					>
 						Disabled Checked
+					</Switch>
+
+					<Switch id={`switch-${c}-loading`} isLoading={true} color={c as any}>
+						Loading
+					</Switch>
+
+					<Switch
+						id={`switch-${c}-loading-checked`}
+						defaultValue={true}
+						isLoading={true}
+						color={c as any}
+					>
+						Loading Checked
 					</Switch>
 				</div>
 			))}

--- a/packages/ui/src/switch/switch.forward-ref.test.tsx
+++ b/packages/ui/src/switch/switch.forward-ref.test.tsx
@@ -10,4 +10,10 @@ describe('Switch forwardRef', () => {
 		render(<Switch ref={ref} />);
 		expect(ref.current).toBeInstanceOf(HTMLButtonElement);
 	});
+
+	it('forwards ref with isLoading prop', () => {
+		const ref = createRef<HTMLButtonElement>();
+		render(<Switch ref={ref} isLoading />);
+		expect(ref.current).toBeInstanceOf(HTMLButtonElement);
+	});
 });

--- a/packages/ui/src/switch/switch.isLoading.test.tsx
+++ b/packages/ui/src/switch/switch.isLoading.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Switch } from './index.js';
+
+describe('Switch — isLoading', () => {
+	it('renders the spinner when isLoading is true', () => {
+		render(<Switch isLoading />);
+		expect(screen.getByTestId('switch-loading-icon')).toBeInTheDocument();
+	});
+
+	it('does not render the spinner when isLoading is false', () => {
+		render(<Switch isLoading={false} />);
+		expect(screen.queryByTestId('switch-loading-icon')).not.toBeInTheDocument();
+	});
+
+	it('sets data-loading attribute when isLoading is true', () => {
+		render(<Switch isLoading />);
+		expect(screen.getByRole('switch')).toHaveAttribute('data-loading');
+	});
+
+	it('does not set data-loading attribute when isLoading is false', () => {
+		render(<Switch isLoading={false} />);
+		expect(screen.getByRole('switch')).not.toHaveAttribute('data-loading');
+	});
+
+	it('disables the switch when isLoading is true', () => {
+		render(<Switch isLoading />);
+		expect(screen.getByRole('switch')).toBeDisabled();
+	});
+
+	it('sets aria-busy when isLoading is true', () => {
+		render(<Switch isLoading />);
+		expect(screen.getByRole('switch')).toHaveAttribute('aria-busy', 'true');
+	});
+
+	it('does not set aria-busy when isLoading is false', () => {
+		render(<Switch isLoading={false} />);
+		expect(screen.getByRole('switch')).not.toHaveAttribute('aria-busy');
+	});
+
+	it('does not fire onChange while loading', () => {
+		const onChange = vi.fn();
+		render(<Switch isLoading onChange={onChange} />);
+		fireEvent.click(screen.getByRole('switch'));
+		expect(onChange).not.toHaveBeenCalled();
+	});
+
+	it('loading styles take precedence over disabled when both are set', () => {
+		render(<Switch isLoading disabled />);
+		const switchEl = screen.getByRole('switch');
+		expect(switchEl).toHaveAttribute('data-loading');
+		expect(switchEl).toBeDisabled();
+		expect(screen.getByTestId('switch-loading-icon')).toBeInTheDocument();
+	});
+});

--- a/packages/ui/src/switch/switch.module.scss
+++ b/packages/ui/src/switch/switch.module.scss
@@ -91,7 +91,7 @@
     width: var(--switch-loading-icon-size, .5rem);
     height: var(--switch-loading-icon-size, .5rem);
     flex-shrink: 0;
-    animation: var(--switch-animate-spin, switch-spin 0.7s linear infinite);
+    animation: switch-spin 0.7s linear infinite;
     color: var(--switch-loading-icon-color, var(--text-ink-500));
 
     @media (prefers-reduced-motion: reduce) {

--- a/packages/ui/src/switch/switch.module.scss
+++ b/packages/ui/src/switch/switch.module.scss
@@ -1,3 +1,9 @@
+@keyframes switch-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .switch-wrapper {
   display: flex;
   align-items: center;
@@ -56,14 +62,45 @@
     outline: 2px solid var(--switch-checked-background);
   }
 
-  &:disabled {
+  &:disabled:not([data-loading]) {
     cursor: not-allowed;
     opacity: 0.5;
   }
 
-  &:disabled ~ .switch-label {
+  &:disabled:not([data-loading]) ~ .switch-label {
     cursor: not-allowed;
     opacity: 0.7;
+  }
+
+  &[data-loading] {
+    cursor: wait;
+    opacity: 0.7;
+  }
+
+  &[data-loading] ~ .switch-label {
+    cursor: wait;
+  }
+
+  &[data-loading] &__thumb {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__loading-icon {
+    width: var(--switch-loading-icon-size, .5rem);
+    height: var(--switch-loading-icon-size, .5rem);
+    flex-shrink: 0;
+    animation: var(--switch-animate-spin, switch-spin 0.7s linear infinite);
+    color: var(--switch-loading-icon-color, var(--text-ink-500));
+
+    @media (prefers-reduced-motion: reduce) {
+      animation: none;
+    }
+  }
+
+  &[data-state="checked"] &__loading-icon {
+    color: var(--switch-loading-icon-color, var(--switch-checked-background));
   }
 
   &__thumb {

--- a/packages/ui/src/switch/switch.tsx
+++ b/packages/ui/src/switch/switch.tsx
@@ -1,4 +1,5 @@
 import * as SwitchPrimitive from '@radix-ui/react-switch';
+import { LoaderCircle } from '@signozhq/icons';
 import * as React from 'react';
 import { useId } from 'react';
 import { cn } from '../lib/utils.js';
@@ -56,22 +57,51 @@ export type SwitchProps = Pick<
 	 * @default 'robin'
 	 */
 	color?: SwitchColor;
+	/**
+	 * When true, shows a loading spinner in the thumb and prevents user interaction.
+	 * @default false
+	 */
+	isLoading?: boolean;
 };
 
 const SwitchBase = React.forwardRef<React.ElementRef<typeof SwitchPrimitive.Root>, SwitchProps>(
-	({ className, style, testId, value, onChange, defaultValue, color = 'robin', ...props }, ref) => (
+	(
+		{
+			className,
+			style,
+			testId,
+			value,
+			onChange,
+			defaultValue,
+			color = 'robin',
+			disabled,
+			isLoading = false,
+			...props
+		},
+		ref
+	) => (
 		<SwitchPrimitive.Root
 			ref={ref}
 			data-color={color}
+			data-loading={isLoading ? '' : undefined}
 			className={cn(styles['switch'], className)}
 			data-testid={testId}
 			style={style}
 			checked={value}
 			onCheckedChange={onChange}
 			defaultChecked={defaultValue}
+			disabled={disabled || isLoading}
+			aria-busy={isLoading || undefined}
 			{...props}
 		>
-			<SwitchPrimitive.Thumb className={styles['switch__thumb']} />
+			<SwitchPrimitive.Thumb className={styles['switch__thumb']}>
+				{isLoading && (
+					<LoaderCircle
+						data-testid="switch-loading-icon"
+						className={styles['switch__loading-icon']}
+					/>
+				)}
+			</SwitchPrimitive.Thumb>
 		</SwitchPrimitive.Root>
 	)
 );
@@ -109,6 +139,12 @@ SwitchBase.displayName = SwitchPrimitive.Root.displayName;
  * ```tsx
  * // Disabled state
  * <Switch disabled>Maintenance mode</Switch>
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Loading state — shows spinner and prevents interaction
+ * <Switch isLoading>Saving…</Switch>
  * ```
  */
 const SwitchWrapper = React.forwardRef<React.ElementRef<typeof SwitchPrimitive.Root>, SwitchProps>(


### PR DESCRIPTION
## Summary                                                                                             
  Closes #226                                                                                            
                                                                                                       
  Adds an `isLoading` prop to the `Switch` component to represent an async in-progress state (e.g. saving
   a setting, toggling a feature flag via API call).                                                     
                                                                                                       
  ### What changed                                                                                       
                                                                                                       
  - **`Switch` component** — new `isLoading?: boolean` prop (default `false`):                         
    - Renders a spinning `LoaderCircle` icon inside the thumb when `true`                                
    - Disables interaction (`disabled || isLoading`) and sets `aria-busy` for accessibility
    - Uses `data-loading` attribute to scope styles independently from the `disabled` state              
  - **Styles** — new `switch-spin` keyframe animation; `cursor: wait` and `opacity: 0.7` for the loading 
  state; icon color adapts to checked/unchecked state; animation is suppressed when                      
  `prefers-reduced-motion: reduce` is set                                                                
  - **Tests** — dedicated `switch.isLoading.test.tsx` covering rendering, interaction prevention, and    
  accessibility attributes                                                                               
  - **Storybook** — loading state story added                                                            
                                                                                                       
  ### Behaviour                                                                                          
                                                                                                       
  | State | Cursor | Opacity | Interaction |                                                           
  |---|---|---|---|                                                                                      
  | `disabled` | `not-allowed` | `0.5` | blocked |
  | `isLoading` | `wait` | `0.7` | blocked |                                                             
                                                                                                         
  ### Evidence                                                                               
                                                                                                         
  https://github.com/user-attachments/assets/bf114a7b-92f7-4951-b70c-6bc263e01cd6                      
       