### PR TITLE
  feat(tabs): add tabBarLeftContent/tabBarRightContent extra content slots  

### DIFF
--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -6,11 +6,23 @@ import {
 	LayoutGrid,
 	List,
 	Lock,
+	Plus,
 	Settings,
 	Settings2,
 	ShieldAlert,
 } from '@signozhq/icons';
-import { type TabItemProps, Tabs, type TabVariants } from '@signozhq/ui';
+import {
+	Button,
+	ButtonColor,
+	ButtonSize,
+	ButtonVariant,
+	type TabItemProps,
+	Tabs,
+	TabsList,
+	TabsRoot,
+	TabsTrigger,
+	type TabVariants,
+} from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof Tabs> = {
@@ -389,6 +401,115 @@ export const Secondary: Story = {
 		variant: 'secondary',
 		defaultValue: 'all',
 	},
+};
+
+export const TabBarExtraContent: Story = {
+	render: () => (
+		<div className="space-y-8 p-6">
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Primary — right-only (Add view button)</h2>
+				<Tabs
+					items={primaryItems}
+					variant="primary"
+					defaultValue="overview"
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							Add view
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Primary — both left and right content</h2>
+				<Tabs
+					items={primaryItems}
+					variant="primary"
+					defaultValue="overview"
+					tabBarLeftContent={<span className="text-xs opacity-50">Service: frontend</span>}
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Settings className="size-4" />}
+						>
+							Configure
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Secondary — right-only</h2>
+				<Tabs
+					items={secondaryItems}
+					variant="secondary"
+					defaultValue="all"
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							New endpoint
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Secondary — left and right content</h2>
+				<Tabs
+					items={secondaryItems}
+					variant="secondary"
+					defaultValue="all"
+					tabBarLeftContent={<span className="text-xs opacity-50">v2 API</span>}
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							New endpoint
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">
+					Primitive TabsList — rightContent prop directly
+				</h2>
+				<TabsRoot defaultValue="tab1">
+					<TabsList
+						variant="primary"
+						rightContent={
+							<Button
+								variant={ButtonVariant.Outlined}
+								size={ButtonSize.SM}
+								color={ButtonColor.Secondary}
+								prefix={<Plus className="size-4" />}
+							>
+								Add
+							</Button>
+						}
+					>
+						<TabsTrigger value="tab1">Tab One</TabsTrigger>
+						<TabsTrigger value="tab2">Tab Two</TabsTrigger>
+						<TabsTrigger value="tab3">Tab Three</TabsTrigger>
+					</TabsList>
+				</TabsRoot>
+			</div>
+		</div>
+	),
 };
 
 export const DisabledStates: Story = {

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -7,15 +7,47 @@
 .tabs__list-wrapper {
   &[data-variant="primary"] {
     display: inline-flex;
-    align-items: flex-start;
+    align-items: center;
     text-align: left;
-    position: relative;
+    gap: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+  }
+
+  &[data-variant="primary"][data-has-extra-content] {
+    display: flex;
   }
 
   &[data-variant="secondary"] {
     display: flex;
     width: 100%;
     padding-left: var(--tab-list-wrapper-secondary-padding-left, var(--spacing-8, 16px));
+  }
+}
+
+.tabs__list-inner {
+  display: inline-flex;
+  align-items: flex-start;
+  position: relative;
+}
+
+.tabs__extra-content {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+
+  [data-variant="secondary"] & {
+    border-bottom: var(--tab-border-spacer-border-width, 1px) solid var(--tab-border-color, var(--l1-border));
+  }
+
+  // Left slot: pad right so the border-bottom extends as a spacer before Tab1,
+  // giving the same 16 px blank zone the left border-spacer normally provides.
+  [data-variant="secondary"] &:first-child {
+    padding-right: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+  }
+
+  // Right slot: pad left so there's visual breathing room between the grow-spacer
+  // and the right-side content (mirrors the left indent on the opposite side).
+  [data-variant="secondary"] &:last-child {
+    padding-left: var(--tab-bar-content-gap, var(--spacing-8, 16px));
   }
 }
 

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -30,23 +30,19 @@
 }
 
 .tabs__extra-content {
-  display: flex;
-  align-items: center;
-  flex-shrink: 0;
+  display: var(--tab-extra-content-display, flex);
+  align-items: var(--tab-extra-content-align-items, center);
+  flex-shrink: var(--tab-extra-content-flex-shrink, 0);
 
   [data-variant="secondary"] & {
     border-bottom: var(--tab-border-spacer-border-width, 1px) solid var(--tab-border-color, var(--l1-border));
   }
 
-  // Left slot: pad right so the border-bottom extends as a spacer before Tab1,
-  // giving the same 16 px blank zone the left border-spacer normally provides.
-  [data-variant="secondary"] &:first-child {
+  [data-variant="secondary"] &[data-slot="tab-extra-content-left"] {
     padding-right: var(--tab-bar-content-gap, var(--spacing-8, 16px));
   }
 
-  // Right slot: pad left so there's visual breathing room between the grow-spacer
-  // and the right-side content (mirrors the left indent on the opposite side).
-  [data-variant="secondary"] &:last-child {
+  [data-variant="secondary"] &[data-slot="tab-extra-content-right"] {
     padding-left: var(--tab-bar-content-gap, var(--spacing-8, 16px));
   }
 }

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -357,7 +357,11 @@ export const TabsList = React.forwardRef<
 				data-variant={variant}
 				data-has-extra-content={leftContent || rightContent ? '' : undefined}
 			>
-				{leftContent && <div className={styles['tabs__extra-content']}>{leftContent}</div>}
+				{leftContent && (
+					<div data-slot="tab-extra-content-left" className={styles['tabs__extra-content']}>
+						{leftContent}
+					</div>
+				)}
 
 				{variant === 'secondary' && !leftContent && (
 					<div className={styles['tabs__border-spacer']} />
@@ -399,11 +403,18 @@ export const TabsList = React.forwardRef<
 					</TabsPrimitive.List>
 				)}
 
-				{variant === 'secondary' && (
-					<div className={cn(styles['tabs__border-spacer'], styles['tabs__border-spacer--grow'])} />
+				{rightContent && (
+					<div data-slot="tab-extra-content-right" className={styles['tabs__extra-content']}>
+						{rightContent}
+					</div>
 				)}
 
-				{rightContent && <div className={styles['tabs__extra-content']}>{rightContent}</div>}
+				{variant === 'secondary' && (
+					<div
+						data-slot="tab-spacer-grow"
+						className={cn(styles['tabs__border-spacer'], styles['tabs__border-spacer--grow'])}
+					/>
+				)}
 			</div>
 		);
 	}

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -83,6 +83,14 @@ export type TabsProps = Pick<
 	 * @default 'automatic'
 	 */
 	activationMode?: 'automatic' | 'manual';
+	/**
+	 * Content rendered to the left of the tab list, in the same horizontal row.
+	 */
+	tabBarLeftContent?: React.ReactNode;
+	/**
+	 * Content rendered to the right of the tab list, in the same horizontal row.
+	 */
+	tabBarRightContent?: React.ReactNode;
 };
 
 /**
@@ -127,7 +135,18 @@ export type TabsProps = Pick<
  */
 export const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>, TabsProps>(
 	(
-		{ items, onChange, defaultValue, value, variant = 'primary', className, testId, ...props },
+		{
+			items,
+			onChange,
+			defaultValue,
+			value,
+			variant = 'primary',
+			className,
+			testId,
+			tabBarLeftContent,
+			tabBarRightContent,
+			...props
+		},
 		ref
 	) => {
 		return (
@@ -141,7 +160,11 @@ export const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>
 				{...props}
 			>
 				<TooltipProvider>
-					<TabsList variant={variant}>
+					<TabsList
+						variant={variant}
+						leftContent={tabBarLeftContent}
+						rightContent={tabBarRightContent}
+					>
 						{items.map((item) => {
 							const triggerContent = (
 								<TabsTrigger
@@ -201,6 +224,14 @@ export type TabsListProps = Pick<
 	 * When true, keyboard navigation will loop from last tab to first, and vice versa.
 	 */
 	loop?: boolean;
+	/**
+	 * Content rendered to the left of the tab list, in the same horizontal row.
+	 */
+	leftContent?: React.ReactNode;
+	/**
+	 * Content rendered to the right of the tab list, in the same horizontal row.
+	 */
+	rightContent?: React.ReactNode;
 };
 
 /**
@@ -228,129 +259,155 @@ export type TabsListProps = Pick<
 export const TabsList = React.forwardRef<
 	React.ElementRef<typeof TabsPrimitive.List>,
 	TabsListProps
->(({ className, variant = 'primary', children, testId, ...props }, ref) => {
-	const listRef = React.useRef<HTMLDivElement>(null);
-	const activeSliderRef = React.useRef<HTMLDivElement>(null);
-	const hoverSliderRef = React.useRef<HTMLDivElement>(null);
+>(
+	(
+		{ className, variant = 'primary', children, testId, leftContent, rightContent, ...props },
+		ref
+	) => {
+		const listRef = React.useRef<HTMLDivElement>(null);
+		const activeSliderRef = React.useRef<HTMLDivElement>(null);
+		const hoverSliderRef = React.useRef<HTMLDivElement>(null);
 
-	// Combine refs
-	React.useImperativeHandle(ref, () => listRef.current as HTMLDivElement);
+		// Combine refs
+		React.useImperativeHandle(ref, () => listRef.current as HTMLDivElement);
 
-	const updateSliderPosition = React.useCallback(
-		(slider: HTMLDivElement | null, trigger: HTMLElement | null) => {
-			if (!slider || !trigger || !listRef.current) {
-				if (slider) slider.style.opacity = '0';
-				return;
-			}
-
-			const listRect = listRef.current.getBoundingClientRect();
-			const triggerRect = trigger.getBoundingClientRect();
-			const offset = triggerRect.left - listRect.left;
-
-			slider.style.transform = `translateX(${offset}px)`;
-			slider.style.width = `${triggerRect.width}px`;
-			slider.style.opacity = '1';
-		},
-		[]
-	);
-
-	const updateActiveSlider = React.useCallback(() => {
-		if (variant !== 'primary' || !listRef.current) return;
-
-		const activeTrigger = listRef.current.querySelector<HTMLElement>(
-			'[data-slot="tabs-trigger"][data-state="active"]'
-		);
-		updateSliderPosition(activeSliderRef.current, activeTrigger);
-	}, [variant, updateSliderPosition]);
-
-	// Update active slider on mount and when children change
-	React.useEffect(() => {
-		if (variant !== 'primary') return;
-
-		requestAnimationFrame(updateActiveSlider);
-
-		// Observe for data-state changes on triggers
-		const list = listRef.current;
-		if (!list) return;
-
-		const observer = new MutationObserver((mutations) => {
-			for (const mutation of mutations) {
-				if (mutation.type === 'attributes' && mutation.attributeName === 'data-state') {
-					updateActiveSlider();
-					break;
+		const updateSliderPosition = React.useCallback(
+			(slider: HTMLDivElement | null, trigger: HTMLElement | null) => {
+				if (!slider || !trigger || !listRef.current) {
+					if (slider) slider.style.opacity = '0';
+					return;
 				}
-			}
-		});
 
-		observer.observe(list, {
-			attributes: true,
-			attributeFilter: ['data-state'],
-			subtree: true,
-		});
+				const listRect = listRef.current.getBoundingClientRect();
+				const triggerRect = trigger.getBoundingClientRect();
+				const offset = triggerRect.left - listRect.left;
 
-		return () => observer.disconnect();
-	}, [variant, updateActiveSlider]);
+				slider.style.transform = `translateX(${offset}px)`;
+				slider.style.width = `${triggerRect.width}px`;
+				slider.style.opacity = '1';
+			},
+			[]
+		);
 
-	React.useEffect(() => {
-		if (variant !== 'primary') return;
+		const updateActiveSlider = React.useCallback(() => {
+			if (variant !== 'primary' || !listRef.current) return;
 
-		const handleResize = () => updateActiveSlider();
-		window.addEventListener('resize', handleResize);
-		return () => window.removeEventListener('resize', handleResize);
-	}, [variant, updateActiveSlider]);
+			const activeTrigger = listRef.current.querySelector<HTMLElement>(
+				'[data-slot="tabs-trigger"][data-state="active"]'
+			);
+			updateSliderPosition(activeSliderRef.current, activeTrigger);
+		}, [variant, updateSliderPosition]);
 
-	const handleMouseOver = React.useCallback(
-		(e: React.MouseEvent) => {
+		// Update active slider on mount and when children change
+		React.useEffect(() => {
 			if (variant !== 'primary') return;
 
-			const trigger = (e.target as HTMLElement).closest<HTMLElement>('[data-slot="tabs-trigger"]');
-			if (trigger) {
-				updateSliderPosition(hoverSliderRef.current, trigger);
-			}
-		},
-		[variant, updateSliderPosition]
-	);
+			requestAnimationFrame(updateActiveSlider);
 
-	const handleMouseLeave = React.useCallback(() => {
-		if (variant !== 'primary') return;
+			// Observe for data-state changes on triggers
+			const list = listRef.current;
+			if (!list) return;
 
-		const slider = hoverSliderRef.current;
-		if (slider) slider.style.opacity = '0';
-	}, [variant]);
+			const observer = new MutationObserver((mutations) => {
+				for (const mutation of mutations) {
+					if (mutation.type === 'attributes' && mutation.attributeName === 'data-state') {
+						updateActiveSlider();
+						break;
+					}
+				}
+			});
 
-	return (
-		<div className={styles['tabs__list-wrapper']} data-variant={variant}>
-			{variant === 'secondary' && <div className={styles['tabs__border-spacer']} />}
-			<TabsPrimitive.List
-				ref={listRef}
-				className={cn(styles['tabs__list'], className)}
+			observer.observe(list, {
+				attributes: true,
+				attributeFilter: ['data-state'],
+				subtree: true,
+			});
+
+			return () => observer.disconnect();
+		}, [variant, updateActiveSlider]);
+
+		React.useEffect(() => {
+			if (variant !== 'primary') return;
+
+			const handleResize = () => updateActiveSlider();
+			window.addEventListener('resize', handleResize);
+			return () => window.removeEventListener('resize', handleResize);
+		}, [variant, updateActiveSlider]);
+
+		const handleMouseOver = React.useCallback(
+			(e: React.MouseEvent) => {
+				const trigger = (e.target as HTMLElement).closest<HTMLElement>(
+					'[data-slot="tabs-trigger"]'
+				);
+				if (trigger) {
+					updateSliderPosition(hoverSliderRef.current, trigger);
+				}
+			},
+			[updateSliderPosition]
+		);
+
+		const handleMouseLeave = React.useCallback(() => {
+			const slider = hoverSliderRef.current;
+			if (slider) slider.style.opacity = '0';
+		}, []);
+
+		return (
+			<div
+				className={styles['tabs__list-wrapper']}
 				data-variant={variant}
-				data-testid={testId}
-				onMouseOver={variant === 'primary' ? handleMouseOver : undefined}
-				onMouseLeave={variant === 'primary' ? handleMouseLeave : undefined}
-				{...props}
+				data-has-extra-content={leftContent || rightContent ? '' : undefined}
 			>
-				{children}
-			</TabsPrimitive.List>
-			{variant === 'secondary' ? (
-				<div className={cn(styles['tabs__border-spacer'], styles['tabs__border-spacer--grow'])} />
-			) : (
-				<>
-					<div
-						ref={hoverSliderRef}
-						className={styles['tabs__hover-slider']}
-						style={{ height: '28px', opacity: 0 }}
-					/>
-					<div
-						ref={activeSliderRef}
-						className={styles['tabs__active-slider']}
-						style={{ opacity: 0 }}
-					/>
-				</>
-			)}
-		</div>
-	);
-});
+				{leftContent && <div className={styles['tabs__extra-content']}>{leftContent}</div>}
+
+				{variant === 'secondary' && !leftContent && (
+					<div className={styles['tabs__border-spacer']} />
+				)}
+
+				{variant === 'primary' ? (
+					<div className={styles['tabs__list-inner']}>
+						<TabsPrimitive.List
+							ref={listRef}
+							className={cn(styles['tabs__list'], className)}
+							data-variant={variant}
+							data-testid={testId}
+							onMouseOver={handleMouseOver}
+							onMouseLeave={handleMouseLeave}
+							{...props}
+						>
+							{children}
+						</TabsPrimitive.List>
+						<div
+							ref={hoverSliderRef}
+							className={styles['tabs__hover-slider']}
+							style={{ height: '28px', opacity: 0 }}
+						/>
+						<div
+							ref={activeSliderRef}
+							className={styles['tabs__active-slider']}
+							style={{ opacity: 0 }}
+						/>
+					</div>
+				) : (
+					<TabsPrimitive.List
+						ref={listRef}
+						className={cn(styles['tabs__list'], className)}
+						data-variant={variant}
+						data-testid={testId}
+						{...props}
+					>
+						{children}
+					</TabsPrimitive.List>
+				)}
+
+				{variant === 'secondary' && (
+					<div className={cn(styles['tabs__border-spacer'], styles['tabs__border-spacer--grow'])} />
+				)}
+
+				{rightContent && <div className={styles['tabs__extra-content']}>{rightContent}</div>}
+			</div>
+		);
+	}
+);
 TabsList.displayName = 'TabsList';
 
 export type TabsTriggerProps = Pick<


### PR DESCRIPTION
 Description:                                                                                           
                                                                                                         
  Closes #224                                                                                          
                                         
  ## What                                                                                              
                                                                                                       
  Adds support for rendering custom content in the same horizontal row as the tab bar — both to the left 
  and right of the tabs.
                                                                                                         
  ### New props                                                                                          
                                         
  | Prop | Component | Description |                                                                     
  |---|---|---|                                                                                        
  | `tabBarLeftContent` | `Tabs` | Content rendered left of the tab list |
  | `tabBarRightContent` | `Tabs` | Content rendered right of the tab list |                             
  | `leftContent` | `TabsList` | Same, on the primitive directly |                                     
  | `rightContent` | `TabsList` | Same, on the primitive directly |                                      
                                                                                                       
  Works on both `primary` and `secondary` variants.                                                      
                                                                                                       
  ## How                                                                                                 
                                                                                                       
  - Primary variant: wraps the list + sliders in a new `tabs__list-inner` div so the animated sliders    
  stay correctly anchored when extra content shifts the layout                                         
  - Secondary variant: replaces the left border-spacer with the `leftContent` slot (preserving           
  bottom-border continuity via CSS), and appends `rightContent` after the grow-spacer                    
                                         
  ## Evidence                                                                               
                                                                                                       
<img width="2940" height="1754" alt="image" src="https://github.com/user-attachments/assets/1544da31-4719-4fc6-978c-37994f1d5df2" />        
                                                                                                       
  ## Story

  `Components/Tabs → Tab Bar Extra Content` — covers:                                                    
  - Primary, right-only
  - Primary, left + right                                                                                
  - Secondary, right-only                                                                              
  - Secondary, left + right                                                                              
  - Raw `TabsList` primitive with `rightContent`                                                       
    

