### PR TITLE
 feat(tabs): add alignment prop to control tab list positioning 

### DIFF
--- a/apps/docs/stories/tabs-list.stories.tsx
+++ b/apps/docs/stories/tabs-list.stories.tsx
@@ -26,6 +26,16 @@ const meta: Meta<typeof TabsList> = {
 				'When true, keyboard navigation will loop from last tab to first, and vice versa.',
 			table: { category: 'Behavior', type: { summary: 'boolean' } },
 		},
+		alignment: {
+			control: 'select',
+			options: ['left', 'center', 'right'],
+			description: 'Controls the alignment of the tab list within its container.',
+			table: {
+				category: 'Layout',
+				type: { summary: "'left' | 'center' | 'right'" },
+				defaultValue: { summary: "'left'" },
+			},
+		},
 		id: {
 			control: 'text',
 			description: 'A unique identifier for the tabs list.',

--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -25,6 +25,7 @@ import {
 	type TabVariants,
 } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import type * as React from 'react';
 
 const meta: Meta<typeof Tabs> = {
 	title: 'Composed Components/Tabs/TabsSimple',
@@ -529,133 +530,66 @@ const alignmentItems: TabItemProps[] = [
 	{ key: 'settings', label: 'Settings', children: 'Settings content' },
 ];
 
+const leftExtra = <span className="text-xs opacity-60">v2 API</span>;
+const rightExtra = (
+	<Button
+		variant={ButtonVariant.Outlined}
+		size={ButtonSize.SM}
+		color={ButtonColor.Secondary}
+		prefix={<Plus className="size-4" />}
+	>
+		Add view
+	</Button>
+);
+
+type ExtraVariant = 'empty' | 'left' | 'right' | 'both';
+
+const extraConfigs: Record<
+	ExtraVariant,
+	{ label: string; tabBarLeftContent?: React.ReactNode; tabBarRightContent?: React.ReactNode }
+> = {
+	empty: { label: 'No extra content' },
+	left: { label: 'Left content only', tabBarLeftContent: leftExtra },
+	right: { label: 'Right content only', tabBarRightContent: rightExtra },
+	both: {
+		label: 'Left + right content',
+		tabBarLeftContent: leftExtra,
+		tabBarRightContent: rightExtra,
+	},
+};
+
 export const Alignment: Story = {
 	render: () => (
-		<div className="space-y-8">
-			{(['left', 'center', 'right'] as TabsAlignment[]).map((alignment) => (
-				<div key={alignment}>
-					<h2 className="mb-4 text-lg font-semibold capitalize">Primary — {alignment}</h2>
-					<Tabs
-						items={alignmentItems}
-						variant="primary"
-						alignment={alignment}
-						defaultValue="overview"
-					/>
-				</div>
+		<div className="space-y-12 p-6">
+			{(['primary', 'secondary'] as TabVariants[]).map((variant) => (
+				<section key={variant}>
+					<h1 className="mb-6 border-b pb-2 text-xl font-bold capitalize">{variant} variant</h1>
+					{(['left', 'center', 'right'] as TabsAlignment[]).map((alignment) => (
+						<div key={alignment} className="mb-10">
+							<h2 className="mb-4 text-base font-semibold capitalize">{alignment} alignment</h2>
+							<div className="space-y-6">
+								{(Object.keys(extraConfigs) as ExtraVariant[]).map((extraVariant) => {
+									const { label, tabBarLeftContent, tabBarRightContent } =
+										extraConfigs[extraVariant];
+									return (
+										<div key={extraVariant}>
+											<p className="mb-2 font-mono text-xs opacity-50">{label}</p>
+											<Tabs
+												items={alignmentItems}
+												variant={variant}
+												alignment={alignment}
+												defaultValue="overview"
+												tabBarLeftContent={tabBarLeftContent}
+												tabBarRightContent={tabBarRightContent}
+											/>
+										</div>
+									);
+								})}
+							</div>
+						</div>
+					))}
+				</section>
 			))}
-			{(['left', 'center', 'right'] as TabsAlignment[]).map((alignment) => (
-				<div key={`secondary-${alignment}`}>
-					<h2 className="mb-4 text-lg font-semibold capitalize">Secondary — {alignment}</h2>
-					<Tabs
-						items={alignmentItems}
-						variant="secondary"
-						alignment={alignment}
-						defaultValue="overview"
-					/>
-				</div>
-			))}
-
-			<div>
-				<h2 className="mb-4 text-lg font-semibold">Primary — center + right content</h2>
-				<Tabs
-					items={alignmentItems}
-					variant="primary"
-					alignment="center"
-					defaultValue="overview"
-					tabBarRightContent={
-						<Button
-							variant={ButtonVariant.Outlined}
-							size={ButtonSize.SM}
-							color={ButtonColor.Secondary}
-							prefix={<Plus className="size-4" />}
-						>
-							Add view
-						</Button>
-					}
-				/>
-			</div>
-
-			<div>
-				<h2 className="mb-4 text-lg font-semibold">Primary — center + left and right content</h2>
-				<Tabs
-					items={alignmentItems}
-					variant="primary"
-					alignment="center"
-					defaultValue="overview"
-					tabBarLeftContent={<span className="text-xs opacity-50">Service: frontend</span>}
-					tabBarRightContent={
-						<Button
-							variant={ButtonVariant.Outlined}
-							size={ButtonSize.SM}
-							color={ButtonColor.Secondary}
-							prefix={<Settings className="size-4" />}
-						>
-							Configure
-						</Button>
-					}
-				/>
-			</div>
-
-			<div>
-				<h2 className="mb-4 text-lg font-semibold">Primary — right + right content</h2>
-				<Tabs
-					items={alignmentItems}
-					variant="primary"
-					alignment="right"
-					defaultValue="overview"
-					tabBarRightContent={
-						<Button
-							variant={ButtonVariant.Outlined}
-							size={ButtonSize.SM}
-							color={ButtonColor.Secondary}
-							prefix={<Plus className="size-4" />}
-						>
-							Add view
-						</Button>
-					}
-				/>
-			</div>
-
-			<div>
-				<h2 className="mb-4 text-lg font-semibold">Secondary — center + right content</h2>
-				<Tabs
-					items={alignmentItems}
-					variant="secondary"
-					alignment="center"
-					defaultValue="overview"
-					tabBarRightContent={
-						<Button
-							variant={ButtonVariant.Outlined}
-							size={ButtonSize.SM}
-							color={ButtonColor.Secondary}
-							prefix={<Plus className="size-4" />}
-						>
-							Add view
-						</Button>
-					}
-				/>
-			</div>
-
-			<div>
-				<h2 className="mb-4 text-lg font-semibold">Secondary — center + left and right content</h2>
-				<Tabs
-					items={alignmentItems}
-					variant="secondary"
-					alignment="center"
-					defaultValue="overview"
-					tabBarLeftContent={<span className="text-xs opacity-50">v2 API</span>}
-					tabBarRightContent={
-						<Button
-							variant={ButtonVariant.Outlined}
-							size={ButtonSize.SM}
-							color={ButtonColor.Secondary}
-							prefix={<Settings className="size-4" />}
-						>
-							Configure
-						</Button>
-					}
-				/>
-			</div>
 		</div>
 	),
 };

--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -18,6 +18,7 @@ import {
 	ButtonVariant,
 	type TabItemProps,
 	Tabs,
+	type TabsAlignment,
 	TabsList,
 	TabsRoot,
 	TabsTrigger,
@@ -82,6 +83,16 @@ const meta: Meta<typeof Tabs> = {
 				category: 'Behavior',
 				type: { summary: "'automatic' | 'manual'" },
 				defaultValue: { summary: "'automatic'" },
+			},
+		},
+		alignment: {
+			control: 'select',
+			options: ['left', 'center', 'right'],
+			description: 'Controls the alignment of the tab list within its container.',
+			table: {
+				category: 'Layout',
+				type: { summary: "'left' | 'center' | 'right'" },
+				defaultValue: { summary: "'left'" },
 			},
 		},
 		id: {
@@ -507,6 +518,143 @@ export const TabBarExtraContent: Story = {
 						<TabsTrigger value="tab3">Tab Three</TabsTrigger>
 					</TabsList>
 				</TabsRoot>
+			</div>
+		</div>
+	),
+};
+
+const alignmentItems: TabItemProps[] = [
+	{ key: 'overview', label: 'Overview', children: 'Overview content' },
+	{ key: 'analytics', label: 'Analytics', children: 'Analytics content' },
+	{ key: 'settings', label: 'Settings', children: 'Settings content' },
+];
+
+export const Alignment: Story = {
+	render: () => (
+		<div className="space-y-8">
+			{(['left', 'center', 'right'] as TabsAlignment[]).map((alignment) => (
+				<div key={alignment}>
+					<h2 className="mb-4 text-lg font-semibold capitalize">Primary — {alignment}</h2>
+					<Tabs
+						items={alignmentItems}
+						variant="primary"
+						alignment={alignment}
+						defaultValue="overview"
+					/>
+				</div>
+			))}
+			{(['left', 'center', 'right'] as TabsAlignment[]).map((alignment) => (
+				<div key={`secondary-${alignment}`}>
+					<h2 className="mb-4 text-lg font-semibold capitalize">Secondary — {alignment}</h2>
+					<Tabs
+						items={alignmentItems}
+						variant="secondary"
+						alignment={alignment}
+						defaultValue="overview"
+					/>
+				</div>
+			))}
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Primary — center + right content</h2>
+				<Tabs
+					items={alignmentItems}
+					variant="primary"
+					alignment="center"
+					defaultValue="overview"
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							Add view
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Primary — center + left and right content</h2>
+				<Tabs
+					items={alignmentItems}
+					variant="primary"
+					alignment="center"
+					defaultValue="overview"
+					tabBarLeftContent={<span className="text-xs opacity-50">Service: frontend</span>}
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Settings className="size-4" />}
+						>
+							Configure
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Primary — right + right content</h2>
+				<Tabs
+					items={alignmentItems}
+					variant="primary"
+					alignment="right"
+					defaultValue="overview"
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							Add view
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Secondary — center + right content</h2>
+				<Tabs
+					items={alignmentItems}
+					variant="secondary"
+					alignment="center"
+					defaultValue="overview"
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Plus className="size-4" />}
+						>
+							Add view
+						</Button>
+					}
+				/>
+			</div>
+
+			<div>
+				<h2 className="mb-4 text-lg font-semibold">Secondary — center + left and right content</h2>
+				<Tabs
+					items={alignmentItems}
+					variant="secondary"
+					alignment="center"
+					defaultValue="overview"
+					tabBarLeftContent={<span className="text-xs opacity-50">v2 API</span>}
+					tabBarRightContent={
+						<Button
+							variant={ButtonVariant.Outlined}
+							size={ButtonSize.SM}
+							color={ButtonColor.Secondary}
+							prefix={<Settings className="size-4" />}
+						>
+							Configure
+						</Button>
+					}
+				/>
 			</div>
 		</div>
 	),

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -120,6 +120,7 @@
 export {
 	type TabItemProps,
 	Tabs,
+	type TabsAlignment,
 	TabsContent,
 	type TabsContentProps,
 	TabsList,

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -16,10 +16,36 @@
     display: var(--tabs-list-wrapper-primary-extra-content-display, flex);
   }
 
+  &[data-variant="primary"][data-alignment="center"] {
+    display: flex;
+    justify-content: center;
+  }
+
+  &[data-variant="primary"][data-alignment="right"] {
+    display: flex;
+    justify-content: flex-end;
+  }
+
   &[data-variant="secondary"] {
     display: var(--tabs-list-wrapper-secondary-display, flex);
     width: var(--tabs-list-wrapper-secondary-width, 100%);
     padding-left: var(--tabs-list-wrapper-secondary-padding-left, var(--spacing-8, 16px));
+
+    &[data-alignment="center"] {
+      [data-slot="tab-spacer-left"] {
+        flex-grow: 1;
+      }
+    }
+
+    &[data-alignment="right"] {
+      [data-slot="tab-spacer-left"] {
+        flex-grow: 1;
+      }
+
+      [data-slot="tab-spacer-grow"] {
+        flex-grow: 0;
+      }
+    }
   }
 }
 

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -32,8 +32,43 @@
     padding-left: var(--tabs-list-wrapper-secondary-padding-left, var(--spacing-8, 16px));
 
     &[data-alignment="center"] {
+      padding-left: 0;
+
+      // Use flex:1 (flex-basis:0%) on all zone elements so every side starts
+      // from the same base. Spacers and extra-content zones then grow equally,
+      // keeping the tab list truly centered regardless of which side carries
+      // extra content.
       [data-slot="tab-spacer-left"] {
-        flex-grow: 1;
+        flex: 1;
+        min-width: 0;
+        padding-right: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+      }
+
+      [data-slot="tab-spacer-grow"] {
+        flex: 1;
+        min-width: 0;
+        padding-left: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+      }
+
+      &[data-has-left-content] {
+        [data-slot="tab-extra-content-left"] {
+          flex: 1;
+          min-width: 0;
+        }
+      }
+
+      &[data-has-right-content] {
+        [data-slot="tab-extra-content-right"] {
+          flex: 1;
+          justify-content: flex-end;
+          min-width: 0;
+        }
+
+        [data-slot="tab-spacer-grow"] {
+          flex: none;
+          min-width: 0;
+          padding-left: 0;
+        }
       }
     }
 

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -41,13 +41,13 @@
       [data-slot="tab-spacer-left"] {
         flex: 1;
         min-width: 0;
-        padding-right: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+        padding-right: var(--tabs-bar-content-gap, var(--spacing-8, 16px));
       }
 
       [data-slot="tab-spacer-grow"] {
         flex: 1;
         min-width: 0;
-        padding-left: var(--tab-bar-content-gap, var(--spacing-8, 16px));
+        padding-left: var(--tabs-bar-content-gap, var(--spacing-8, 16px));
       }
 
       &[data-has-left-content] {

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -31,44 +31,26 @@
     width: var(--tabs-list-wrapper-secondary-width, 100%);
     padding-left: var(--tabs-list-wrapper-secondary-padding-left, var(--spacing-8, 16px));
 
+    // Left content replaces the visual role of spacer-left; collapse it to
+    // keep the border continuous without adding extra gap.
+    &[data-alignment="left"][data-has-left-content] {
+      [data-slot="tab-spacer-left"] {
+        flex: 0 0 0px;
+        min-width: 0;
+      }
+    }
+
     &[data-alignment="center"] {
       padding-left: 0;
 
-      // Use flex:1 (flex-basis:0%) on all zone elements so every side starts
-      // from the same base. Spacers and extra-content zones then grow equally,
-      // keeping the tab list truly centered regardless of which side carries
-      // extra content.
       [data-slot="tab-spacer-left"] {
         flex: 1;
         min-width: 0;
-        padding-right: var(--tabs-bar-content-gap, var(--spacing-8, 16px));
       }
 
       [data-slot="tab-spacer-grow"] {
         flex: 1;
         min-width: 0;
-        padding-left: var(--tabs-bar-content-gap, var(--spacing-8, 16px));
-      }
-
-      &[data-has-left-content] {
-        [data-slot="tab-extra-content-left"] {
-          flex: 1;
-          min-width: 0;
-        }
-      }
-
-      &[data-has-right-content] {
-        [data-slot="tab-extra-content-right"] {
-          flex: 1;
-          justify-content: flex-end;
-          min-width: 0;
-        }
-
-        [data-slot="tab-spacer-grow"] {
-          flex: none;
-          min-width: 0;
-          padding-left: 0;
-        }
       }
     }
 

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -378,6 +378,8 @@ export const TabsList = React.forwardRef<
 				data-variant={variant}
 				data-alignment={alignment}
 				data-has-extra-content={leftContent || rightContent ? '' : undefined}
+				data-has-left-content={leftContent ? '' : undefined}
+				data-has-right-content={rightContent ? '' : undefined}
 			>
 				{leftContent && (
 					<div data-slot="tab-extra-content-left" className={styles['tabs__extra-content']}>

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -7,6 +7,8 @@ import styles from './tabs.module.scss';
 
 export type TabVariants = 'primary' | 'secondary';
 
+export type TabsAlignment = 'left' | 'center' | 'right';
+
 export type TabItemProps = {
 	/**
 	 * Unique identifier for the tab item.
@@ -91,6 +93,11 @@ export type TabsProps = Pick<
 	 * Content rendered to the right of the tab list, in the same horizontal row.
 	 */
 	tabBarRightContent?: React.ReactNode;
+	/**
+	 * Controls the alignment of the tab list within its container.
+	 * @default 'left'
+	 */
+	alignment?: TabsAlignment;
 };
 
 /**
@@ -141,6 +148,7 @@ export const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>
 			defaultValue,
 			value,
 			variant = 'primary',
+			alignment,
 			className,
 			testId,
 			tabBarLeftContent,
@@ -162,6 +170,7 @@ export const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>
 				<TooltipProvider>
 					<TabsList
 						variant={variant}
+						alignment={alignment}
 						leftContent={tabBarLeftContent}
 						rightContent={tabBarRightContent}
 					>
@@ -174,15 +183,13 @@ export const Tabs = React.forwardRef<React.ElementRef<typeof TabsPrimitive.Root>
 									variant={variant}
 								>
 									{item.disabled ? (
-										<Lock className={styles['tabs__icon']} size={16} />
+										<Lock className={styles.tabs__icon} size={16} />
 									) : (
-										item.prefixIcon && (
-											<span className={styles['tabs__icon']}>{item.prefixIcon}</span>
-										)
+										item.prefixIcon && <span className={styles.tabs__icon}>{item.prefixIcon}</span>
 									)}
 									{item.label}
 									{!item.disabled && item.suffixIcon && (
-										<span className={styles['tabs__icon']}>{item.suffixIcon}</span>
+										<span className={styles.tabs__icon}>{item.suffixIcon}</span>
 									)}
 								</TabsTrigger>
 							);
@@ -232,6 +239,11 @@ export type TabsListProps = Pick<
 	 * Content rendered to the right of the tab list, in the same horizontal row.
 	 */
 	rightContent?: React.ReactNode;
+	/**
+	 * Controls the alignment of the tab list within its container.
+	 * @default 'left'
+	 */
+	alignment?: TabsAlignment;
 };
 
 /**
@@ -261,7 +273,16 @@ export const TabsList = React.forwardRef<
 	TabsListProps
 >(
 	(
-		{ className, variant = 'primary', children, testId, leftContent, rightContent, ...props },
+		{
+			className,
+			variant = 'primary',
+			alignment = 'left',
+			children,
+			testId,
+			leftContent,
+			rightContent,
+			...props
+		},
 		ref
 	) => {
 		const listRef = React.useRef<HTMLDivElement>(null);
@@ -355,6 +376,7 @@ export const TabsList = React.forwardRef<
 			<div
 				className={styles['tabs__list-wrapper']}
 				data-variant={variant}
+				data-alignment={alignment}
 				data-has-extra-content={leftContent || rightContent ? '' : undefined}
 			>
 				{leftContent && (
@@ -364,14 +386,14 @@ export const TabsList = React.forwardRef<
 				)}
 
 				{variant === 'secondary' && !leftContent && (
-					<div className={styles['tabs__border-spacer']} />
+					<div data-slot="tab-spacer-left" className={styles['tabs__border-spacer']} />
 				)}
 
 				{variant === 'primary' ? (
 					<div className={styles['tabs__list-inner']}>
 						<TabsPrimitive.List
 							ref={listRef}
-							className={cn(styles['tabs__list'], className)}
+							className={cn(styles.tabs__list, className)}
 							data-variant={variant}
 							data-testid={testId}
 							onMouseOver={handleMouseOver}
@@ -394,7 +416,7 @@ export const TabsList = React.forwardRef<
 				) : (
 					<TabsPrimitive.List
 						ref={listRef}
-						className={cn(styles['tabs__list'], className)}
+						className={cn(styles.tabs__list, className)}
 						data-variant={variant}
 						data-testid={testId}
 						{...props}
@@ -481,7 +503,7 @@ export const TabsTrigger = React.forwardRef<
 		data-slot="tabs-trigger"
 		data-variant={variant}
 		data-testid={testId}
-		className={cn(styles['tabs__trigger'], className)}
+		className={cn(styles.tabs__trigger, className)}
 		disabled={disabled}
 		{...props}
 	>
@@ -547,7 +569,7 @@ export const TabsContent = React.forwardRef<
 	return (
 		<TabsPrimitive.Content
 			ref={ref}
-			className={cn(styles['tabs__content'], className)}
+			className={cn(styles.tabs__content, className)}
 			data-testid={testId}
 			{...props}
 		/>

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -387,7 +387,7 @@ export const TabsList = React.forwardRef<
 					</div>
 				)}
 
-				{variant === 'secondary' && !leftContent && (
+				{variant === 'secondary' && (
 					<div data-slot="tab-spacer-left" className={styles['tabs__border-spacer']} />
 				)}
 

--- a/packages/ui/src/tabs/tabs.tsx
+++ b/packages/ui/src/tabs/tabs.tsx
@@ -381,14 +381,14 @@ export const TabsList = React.forwardRef<
 				data-has-left-content={leftContent ? '' : undefined}
 				data-has-right-content={rightContent ? '' : undefined}
 			>
+				{variant === 'secondary' && (
+					<div data-slot="tab-spacer-left" className={styles['tabs__border-spacer']} />
+				)}
+
 				{leftContent && (
 					<div data-slot="tab-extra-content-left" className={styles['tabs__extra-content']}>
 						{leftContent}
 					</div>
-				)}
-
-				{variant === 'secondary' && (
-					<div data-slot="tab-spacer-left" className={styles['tabs__border-spacer']} />
 				)}
 
 				{variant === 'primary' ? (


### PR DESCRIPTION
 ## Summary                                                                
  
  Closes #273                                                               
                                                                          
  Adds an `alignment` prop to both the composed `Tabs` and primitive
  `TabsList` components, allowing consumers to control whether the tab list
  aligns to the left (default), center, or right within its container.
                                                                            
  ### Changes                                 
                                                                            
  - New `TabsAlignment = 'left' | 'center' | 'right'` type, exported from 
  the package                                                               
  - `alignment` prop added to `TabsProps` and `TabsListProps`             
  - **Primary variant** — uses `justify-content` (`center` / `flex-end`) on 
  the wrapper                                                             
  - **Secondary variant** — uses a flex spacer technique to push tabs to the
   correct position without breaking the bottom-border line               
  - Both variants support alignment combined with `tabBarLeftContent` /     
  `tabBarRightContent`                                                    
                                                                            
  ### Storybook                                                           
                                                                            
  A new **Alignment** story covers all six combinations (3 alignments × 2 
  variants), plus edge cases with extra bar content:                        
                                                                          
  - Primary left / center / right                                           
  - Secondary left / center / right                                       
  - Primary center + right content                                          
  - Primary center + left and right content                               
  - Primary right + right content         
  - Secondary center + right content                                      
  - Secondary center + left and right content                               
   
   ## Latest Evidence                                           





https://github.com/user-attachments/assets/6523f0d9-404b-4f0d-a43f-52fa830dabde


    
                                          
                                                                            
  ## Test plan                                                            
                                                                            
  - [x] Primary left (default) — tabs hug the left edge                   
  - [x] Primary center — tabs are centered in the container
  - [x] Primary right — tabs are flush to the right                       
  - [x] Secondary center / right — bottom border renders correctly with     
  spacer                                  
  - [x] Alignment + extra bar content renders without layout breakage       
  - [x] No regression on existing `TabBarExtraContent` stories  