### PR TITLE
fix: adding docs for PopoverSimple

### DIFF
--- a/apps/docs/stories/popover-simple.mdx
+++ b/apps/docs/stories/popover-simple.mdx
@@ -1,0 +1,73 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as PopoverSimpleStories from './popover-simple.stories';
+
+<Meta of={PopoverSimpleStories} />
+
+# PopoverSimple
+
+Preset that combines `Popover`, `PopoverTrigger`, and `PopoverContent` in a single component. Pass `trigger` and `children` instead of composing subcomponents.
+
+For full primitive control, see [Popover](?path=/docs/components-popover--docs).
+
+## How to use
+
+```tsx
+import { PopoverSimple, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<PopoverSimple
+			trigger={<Button variant="solid" color="primary">Open</Button>}
+			className="w-64"
+		>
+			<p className="text-sm">Popover content here.</p>
+		</PopoverSimple>
+	);
+}
+```
+
+<Primary />
+
+## Positioning
+
+`side` sets which side of the trigger the popover opens against (`top`, `right`, `bottom`, `left`). `align` controls alignment along that side (`start`, `center`, `end`). Collision detection flips the popover automatically when it would overflow the viewport.
+
+```tsx
+<PopoverSimple side="right" align="start" trigger={<Button>Open</Button>}>
+	Content to the right, aligned to the start
+</PopoverSimple>
+```
+
+## Arrow
+
+Set `arrow` to render a directional indicator pointing toward the trigger.
+
+```tsx
+<PopoverSimple arrow side="bottom" trigger={<Button>Open</Button>}>
+	Content with arrow
+</PopoverSimple>
+```
+
+## Controlled mode
+
+Pass `open` and `onOpenChange` to drive the open state externally.
+
+```tsx
+const [open, setOpen] = React.useState(false);
+
+<PopoverSimple
+	open={open}
+	onOpenChange={setOpen}
+	trigger={<Button>Open</Button>}
+>
+	Controlled content
+</PopoverSimple>
+```
+
+## Nested popovers
+
+`PopoverSimple` always portals its content to `document.body`. If you need to nest one popover inside another and control portaling, use [primitive composition](?path=/docs/components-popover--docs) with `withPortal={false}` on the inner `PopoverContent` directly.
+
+## Props
+
+<Controls of={PopoverSimpleStories.Default} />

--- a/apps/docs/stories/popover-simple.stories.tsx
+++ b/apps/docs/stories/popover-simple.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { simpleArgTypes } from './shared/popover-arg-types.js';
 
 const meta: Meta<typeof PopoverSimple> = {
-	title: 'Composed Components/Popover/PopoverSimple',
+	title: 'Composed Components/PopoverSimple',
 	component: PopoverSimple,
 	argTypes: simpleArgTypes,
 	parameters: {

--- a/apps/docs/stories/popover.mdx
+++ b/apps/docs/stories/popover.mdx
@@ -4,7 +4,6 @@ import * as PopoverPrimitiveStories from './popover-primitive.stories';
 import * as PopoverTriggerStories from './popover-trigger.stories';
 import * as PopoverContentStories from './popover-content.stories';
 import * as PopoverAnchorStories from './popover-anchor.stories';
-import * as PopoverSimpleStories from './popover-simple.stories';
 
 <Meta of={PopoverStories} />
 
@@ -12,32 +11,7 @@ import * as PopoverSimpleStories from './popover-simple.stories';
 
 Displays rich content in a portal, triggered by a button. Use for tooltips, menus, date pickers, and similar patterns.
 
-## How to use
-
-### PopoverSimple (preset)
-
-For simple use cases, use `PopoverSimple` with `trigger` and `children`:
-
-```tsx
-import { PopoverSimple, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	return (
-		<PopoverSimple
-			trigger={<Button variant="outline">Open</Button>}
-			className="w-64"
-		>
-			<p>Simple popover content</p>
-		</PopoverSimple>
-	);
-}
-```
-
-<Primary />
-
-## PopoverSimple Props
-
-<Controls of={PopoverSimpleStories.Default} />
+For the quick-start preset, see [PopoverSimple](?path=/docs/composed-components-popoversimple--docs).
 
 ## Primitive composition
 
@@ -62,6 +36,8 @@ export default function MyComponent() {
 	);
 }
 ```
+
+<Primary />
 
 ### Controlled mode
 


### PR DESCRIPTION

 Description:                                                                                          
                                         
  Closes #271                                                                                           
                                                                                                      
  ## Changes                                 
                                                                                                      
  - Added `popover-simple.mdx` — a dedicated Storybook docs page for                                    
    `PopoverSimple` with sections for basic usage, positioning, arrow,
    controlled mode, nested popovers, and a live Props table.                                           
  - Updated `popover.mdx` to focus solely on primitive composition                                      
    (`Popover`, `PopoverTrigger`, `PopoverContent`, `PopoverAnchor`).
    Replaced the embedded `PopoverSimple` section with a cross-link to                                  
    the new page.                                                                                       
  - Renamed the story category from `Components/Popover/PopoverSimple`                                  
    to `Composed Components/PopoverSimple` — removes the double-nesting                                 
    in the sidebar.                                                                                     
                                                                                                        
  ## Evidence                                                                                            
                                                                                                      

https://github.com/user-attachments/assets/078e8bfa-1a5b-4cc1-bf26-a1dbc259449e
                                                      
                                                                                                        
  ## How to test                                                                                      
                                                                                                        
  ```bash                                                                                             
  pnpm --filter docs dev                 
                                                                                                      
  1. Open Storybook → Composed Components > PopoverSimple — should                                    
  show the new dedicated docs page with live demo and Props table.
  2. Open Components > Popover — should only cover primitives, with                                     
  a link at the top pointing to PopoverSimple.                                                          
  3. Confirm PopoverSimple no longer appears nested under Popover in                                    
  the sidebar.                                                                                          
                                        