### PR TITLE
fix: adding doc for ToggleGroupSimple

### DIFF
--- a/apps/docs/stories/toggle-group-simple.mdx
+++ b/apps/docs/stories/toggle-group-simple.mdx
@@ -1,0 +1,151 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as ToggleGroupSimpleStories from './toggle-group-simple.stories';
+
+<Meta of={ToggleGroupSimpleStories} />
+
+# ToggleGroupSimple
+
+Preset that wraps `ToggleGroup` and `ToggleGroupItem` in a single component. Pass an `items` array instead of composing subcomponents manually.
+
+For full primitive control, see [ToggleGroup](?path=/docs/primitive-components-togglegroup--docs).
+
+## How to use
+
+```tsx
+import { ToggleGroupSimple } from '@signozhq/ui';
+
+const items = [
+	{ value: 'left', label: 'Left' },
+	{ value: 'center', label: 'Center' },
+	{ value: 'right', label: 'Right' },
+];
+
+export default function MyComponent() {
+	return (
+		<ToggleGroupSimple
+			type="single"
+			items={items}
+			defaultValue="center"
+		/>
+	);
+}
+```
+
+<Primary />
+
+## Icon-only items
+
+Add `aria-label` on each item when the label is an icon — required for screen reader accessibility:
+
+```tsx
+import { Bold, Italic, Underline } from '@signozhq/icons';
+
+const items = [
+	{ value: 'bold', label: <Bold className="h-3 w-3" />, 'aria-label': 'Bold' },
+	{ value: 'italic', label: <Italic className="h-3 w-3" />, 'aria-label': 'Italic' },
+	{ value: 'underline', label: <Underline className="h-3 w-3" />, 'aria-label': 'Underline' },
+];
+
+<ToggleGroupSimple type="multiple" items={items} defaultValue={['bold']} />
+```
+
+## Icon + label items
+
+Pass a ReactNode as `label` to render an icon alongside text:
+
+```tsx
+import { LayoutGrid, List } from '@signozhq/icons';
+
+const items = [
+	{ value: 'grid', label: <><LayoutGrid className="h-6 w-6" /> Grid</> },
+	{ value: 'list', label: <><List className="h-6 w-6" /> List</> },
+];
+
+<ToggleGroupSimple type="single" items={items} defaultValue="grid" />
+```
+
+## Multiple selection
+
+Set `type="multiple"` and pass `defaultValue` as an array to allow multiple items to be active at once:
+
+```tsx
+<ToggleGroupSimple
+	type="multiple"
+	items={items}
+	defaultValue={['bold', 'italic']}
+/>
+```
+
+## Controlled usage
+
+Use `value` and `onChange` to control selection externally:
+
+```tsx
+import { useState } from 'react';
+
+function MyComponent() {
+	const [value, setValue] = useState('center');
+
+	return (
+		<ToggleGroupSimple
+			type="single"
+			items={items}
+			value={value}
+			onChange={(v) => setValue(v as string)}
+		/>
+	);
+}
+```
+
+For multiple selection, `onChange` receives `string[]`:
+
+```tsx
+const [values, setValues] = useState<string[]>(['bold']);
+
+<ToggleGroupSimple
+	type="multiple"
+	items={items}
+	value={values}
+	onChange={(v) => setValues(v as string[])}
+/>
+```
+
+## Size variants
+
+Three sizes are available: `sm`, `default`, and `lg`:
+
+```tsx
+<ToggleGroupSimple type="single" size="sm" items={items} defaultValue="center" />
+<ToggleGroupSimple type="single" size="default" items={items} defaultValue="center" />
+<ToggleGroupSimple type="single" size="lg" items={items} defaultValue="center" />
+```
+
+## Color variants
+
+```tsx
+<ToggleGroupSimple type="single" color="primary" items={items} defaultValue="center" />
+<ToggleGroupSimple type="single" color="secondary" items={items} defaultValue="center" />
+<ToggleGroupSimple type="single" color="destructive" items={items} defaultValue="center" />
+<ToggleGroupSimple type="single" color="warning" items={items} defaultValue="center" />
+```
+
+## Disabled state
+
+```tsx
+<ToggleGroupSimple type="single" items={items} defaultValue="center" disabled />
+```
+
+## Vertical orientation
+
+```tsx
+<ToggleGroupSimple
+	type="single"
+	items={items}
+	defaultValue="center"
+	orientation="vertical"
+/>
+```
+
+## Props
+
+<Controls of={ToggleGroupSimpleStories.Default} />

--- a/apps/docs/stories/toggle-group-simple.stories.tsx
+++ b/apps/docs/stories/toggle-group-simple.stories.tsx
@@ -3,7 +3,7 @@ import { ToggleGroupSimple, type ToggleGroupSimpleItem } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof ToggleGroupSimple> = {
-	title: 'Composed Components/ToggleGroup/ToggleGroupSimple',
+	title: 'Composed Components/ToggleGroupSimple',
 	component: ToggleGroupSimple,
 	argTypes: {
 		type: {

--- a/apps/docs/stories/toggle-group.mdx
+++ b/apps/docs/stories/toggle-group.mdx
@@ -1,6 +1,5 @@
 import { Meta, Controls, Story } from '@storybook/addon-docs/blocks';
 import * as ToggleGroupStories from './toggle-group.stories';
-import * as ToggleGroupSimpleStories from './toggle-group-simple.stories';
 import * as ToggleGroupItemStories from './toggle-group-item.stories';
 
 <Meta of={ToggleGroupStories} />
@@ -9,51 +8,9 @@ import * as ToggleGroupItemStories from './toggle-group-item.stories';
 
 A set of two-state buttons that can be toggled on or off, in single or multiple selection mode.
 
-## How to use
+For the quick-start preset, see [ToggleGroupSimple](?path=/docs/composed-components-togglegroupsimple--docs).
 
-### ToggleGroupSimple (preset)
-
-Use `ToggleGroupSimple` for an items-based API. Pass a list of items with `value` and `label` (string, icon, or ReactNode). Supports icon-only, label-only, or icon + label:
-
-```tsx
-import { ToggleGroupSimple } from '@signozhq/ui';
-import { Bold, Italic, LayoutGrid } from '@signozhq/icons';
-
-const items = [
-  { value: 'left', label: 'Left' },
-  { value: 'center', label: 'Center' },
-  { value: 'right', label: 'Right' },
-];
-
-export default function MyComponent() {
-  return (
-    <ToggleGroupSimple
-      type="single"
-      items={items}
-      defaultValue="center"
-    />
-  );
-}
-```
-
-For icon-only items, add `aria-label` for accessibility:
-
-```tsx
-const iconItems = [
-  { value: 'bold', label: <Bold className="h-3 w-3" />, 'aria-label': 'Bold' },
-  { value: 'italic', label: <Italic className="h-3 w-3" />, 'aria-label': 'Italic' },
-];
-
-<ToggleGroupSimple type="multiple" items={iconItems} defaultValue={['bold']} />
-```
-
-<Story of={ToggleGroupSimpleStories.Default} />
-
-## ToggleGroupSimple Props
-
-<Controls of={ToggleGroupSimpleStories.Default} />
-
-### Manual composition with ToggleGroup
+## Basic usage (composition)
 
 For full control over each option, use `ToggleGroup` with `ToggleGroupItem` as children:
 


### PR DESCRIPTION
Closes #269                                                                                                           
                                                                                                                        
  ## Changes                                                                                                              
  
  - Added `toggle-group-simple.mdx` — a dedicated Storybook docs page for                                                 
    `ToggleGroupSimple` with sections for basic usage, icon-only items,                                          
    icon + label items, multiple selection, controlled usage, size variants,
    color variants, disabled state, vertical orientation, and a live Props table.                                         
  - Updated `toggle-group.mdx` to focus solely on primitive composition
    (`ToggleGroup`, `ToggleGroupItem`). Replaced the embedded `ToggleGroupSimple`                                         
    section with a cross-link to the new page.                                                                   
  - Renamed the story category from `Composed Components/ToggleGroup/ToggleGroupSimple`                                   
    to `Composed Components/ToggleGroupSimple` — removes the double-nesting                                             
    in the sidebar.                                                                                                       
                                                                                                                 
  ## Evidence                                                                                                             
              


https://github.com/user-attachments/assets/6c75728f-3853-497b-9792-2bfdc82ad3ba




           

  ## How to test                                                                                                          
                                                                                                                        
  ```bash                                                                                                                 
  pnpm --filter docs dev                                                                                         
                                                                                                                          
  1. Open Storybook → Composed Components > ToggleGroupSimple — should show the                                         
  new dedicated docs page with live demo and Props table.
  2. Open Primitive Components > ToggleGroup — should only cover primitive                                              
  composition, with a link at the top pointing to ToggleGroupSimple.                                                      
  3. Confirm ToggleGroupSimple no longer appears nested under ToggleGroup in
  the sidebar.           