### PR TITLE
docs(tooltip): add dedicated mdx docs for TooltipSimple

### DIFF
--- a/apps/docs/stories/tooltip-simple.mdx
+++ b/apps/docs/stories/tooltip-simple.mdx
@@ -1,0 +1,144 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as TooltipSimpleStories from './tooltip-simple.stories';
+
+<Meta of={TooltipSimpleStories} />
+
+# TooltipSimple
+
+Preset that wraps `TooltipRoot`, `TooltipTrigger`, and `TooltipContent` in a single component. Pass a `title` and a trigger element instead of composing subcomponents manually.
+
+For full primitive control, see [Tooltip](?path=/docs/primitive-components-tooltip--docs).
+
+## How to use
+
+`TooltipSimple` must be rendered inside a `TooltipProvider`. Place the provider once near the root of your app or around a group of tooltips:
+
+```tsx
+import { TooltipSimple, TooltipProvider, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<TooltipProvider>
+			<TooltipSimple title="Helpful information">
+				<Button variant="solid" color="secondary">
+					Hover me
+				</Button>
+			</TooltipSimple>
+		</TooltipProvider>
+	);
+}
+```
+
+<Primary />
+
+## Arrow
+
+Set `arrow` to render a directional indicator pointing toward the trigger:
+
+```tsx
+<TooltipProvider>
+	<TooltipSimple title="With arrow" arrow>
+		<Button>Hover me</Button>
+	</TooltipSimple>
+</TooltipProvider>
+```
+
+## Positioning
+
+`side` sets which side of the trigger the tooltip opens against (`top`, `right`, `bottom`, `left`). `align` controls alignment along that side (`start`, `center`, `end`). Collision detection repositions the tooltip automatically when it would overflow the viewport:
+
+```tsx
+<TooltipProvider>
+	<TooltipSimple title="On the right" side="right" align="start" arrow>
+		<Button>Hover me</Button>
+	</TooltipSimple>
+</TooltipProvider>
+```
+
+Use `sideOffset` and `alignOffset` for pixel-level adjustments:
+
+```tsx
+<TooltipProvider>
+	<TooltipSimple title="Offset" side="bottom" sideOffset={8} alignOffset={4}>
+		<Button>Hover me</Button>
+	</TooltipSimple>
+</TooltipProvider>
+```
+
+## Delay duration
+
+Control how long the pointer must hover before the tooltip opens. Pass `delayDuration` on the `TooltipProvider` to apply it globally, or on the individual tooltip to override it:
+
+```tsx
+<TooltipProvider delayDuration={200}>
+	<TooltipSimple title="Fast tooltip">
+		<Button>Hover me</Button>
+	</TooltipSimple>
+</TooltipProvider>
+```
+
+Per-instance override:
+
+```tsx
+<TooltipSimple title="Instant" delayDuration={0}>
+	<Button>Hover me</Button>
+</TooltipSimple>
+```
+
+## Controlled mode
+
+Pass `open` and `onOpenChange` to drive the open state externally:
+
+```tsx
+import { useState } from 'react';
+import { TooltipSimple, TooltipProvider, Button } from '@signozhq/ui';
+
+function MyComponent() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<TooltipProvider>
+			<TooltipSimple
+				title="Controlled tooltip"
+				open={open}
+				onOpenChange={setOpen}
+			>
+				<Button>Hover me</Button>
+			</TooltipSimple>
+		</TooltipProvider>
+	);
+}
+```
+
+## Inside a modal
+
+When placing a tooltip inside a modal or dialog, set `withPortal={false}` so the tooltip content stays within the modal DOM instead of portaling to `document.body`. This avoids z-index and stacking context issues:
+
+```tsx
+import { Dialog, DialogContent, TooltipSimple, Button } from '@signozhq/ui';
+
+<Dialog>
+	<DialogContent>
+		<TooltipSimple title="Inside modal" withPortal={false}>
+			<Button>Hover me</Button>
+		</TooltipSimple>
+	</DialogContent>
+</Dialog>
+```
+
+## Extra content props
+
+Use `tooltipContentProps` to pass additional props to the underlying `TooltipContent` without losing the preset's composition:
+
+```tsx
+<TooltipSimple
+	title="Custom"
+	tooltipContentProps={{ className: 'max-w-xs', arrowPadding: 8 }}
+>
+	<Button>Hover me</Button>
+</TooltipSimple>
+```
+
+## Props
+
+<Controls of={TooltipSimpleStories.Default} />

--- a/apps/docs/stories/tooltip-simple.stories.tsx
+++ b/apps/docs/stories/tooltip-simple.stories.tsx
@@ -3,7 +3,7 @@ import { Button, ButtonColor, ButtonVariant, TooltipProvider, TooltipSimple } fr
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TooltipSimple> = {
-	title: 'Composed Components/Tooltip/TooltipSimple',
+	title: 'Composed Components/TooltipSimple',
 	component: TooltipSimple,
 	argTypes: {
 		title: {
@@ -100,6 +100,15 @@ const meta: Meta<typeof TooltipSimple> = {
 			control: 'text',
 			description: 'Test ID for the tooltip.',
 			table: { category: 'Testing', type: { summary: 'string' } },
+		},
+		tooltipContentProps: {
+			control: false,
+			description:
+				'Additional props passed to the underlying TooltipContent. Use to set className, arrowPadding, or other TooltipContent props without breaking the preset composition.',
+			table: {
+				category: 'Advanced',
+				type: { summary: 'TooltipContentProps (positioning/arrow props excluded)' },
+			},
 		},
 	},
 	parameters: {

--- a/apps/docs/stories/tooltip.mdx
+++ b/apps/docs/stories/tooltip.mdx
@@ -1,6 +1,5 @@
-import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import { Meta, Controls } from '@storybook/addon-docs/blocks';
 import * as TooltipStories from './tooltip.stories';
-import * as TooltipSimpleStories from './tooltip-simple.stories';
 import * as TooltipProviderStories from './tooltip-provider.stories';
 import * as TooltipTriggerStories from './tooltip-trigger.stories';
 import * as TooltipContentStories from './tooltip-content.stories';
@@ -11,79 +10,13 @@ import * as TooltipContentStories from './tooltip-content.stories';
 
 A customizable tooltip component with smooth animations and flexible positioning.
 
-## How to use
-
-### TooltipSimple (preset)
-
-Minimal preset that wraps a trigger element and shows a tooltip on hover. Handles all the composition internally.
-
-**Basic usage:**
-
-```tsx
-import { TooltipSimple, TooltipProvider } from '@signozhq/ui';
-import { Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	return (
-		<TooltipProvider delayDuration={700}>
-			<TooltipSimple title="Helpful information" arrow>
-				<Button variant="solid" color="secondary">
-					Hover me
-				</Button>
-			</TooltipSimple>
-		</TooltipProvider>
-	);
-}
-```
-
-**With positioning:**
-
-```tsx
-<TooltipSimple title="I appear on the right" side="right" align="start">
-	<Button>Hover me</Button>
-</TooltipSimple>
-```
-
-**Inside a modal/dialog (no portal):**
-
-When placing a tooltip inside a modal or dialog, set `withPortal={false}` so the tooltip content stays within the modal DOM instead of portaling to `document.body`. This avoids z-index and stacking issues.
-
-```tsx
-import { Dialog, DialogContent, TooltipSimple, Button } from '@signozhq/ui';
-
-<Dialog>
-	<DialogContent>
-		<TooltipSimple title="Inside modal" withPortal={false}>
-			<Button>Hover me</Button>
-		</TooltipSimple>
-	</DialogContent>
-</Dialog>
-```
-
-**With extra content props:**
-
-```tsx
-<TooltipSimple
-	title="Custom"
-	tooltipContentProps={{ className: 'custom-class', arrowPadding: 8 }}
->
-	<Button>Hover me</Button>
-</TooltipSimple>
-```
-
-Set `delayDuration={0}` in Storybook for instant feedback.
-
-<Primary />
-
-## TooltipSimple Props
-
-<Controls of={TooltipSimpleStories.Default} />
+For the quick-start preset, see [TooltipSimple](?path=/docs/composed-components-tooltipsimple--docs).
 
 ## TooltipProvider Props
 
 <Controls of={TooltipProviderStories.Default} />
 
-## Primitive composition
+## Basic usage (composition)
 
 For custom content and positioning, use `TooltipRoot`, `TooltipTrigger`, and `TooltipContent`:
 


### PR DESCRIPTION
Closes #268             

  ## Changes                                  
                                          
  - Added `tooltip-simple.mdx` — a dedicated Storybook docs page for
    `TooltipSimple` with sections for basic usage, arrow, positioning,                                                    
    delay duration, controlled mode, inside a modal, extra content props,
    and a live Props table.                                                                                               
  - Updated `tooltip.mdx` to focus solely on primitive composition                                               
    (`TooltipRoot`, `TooltipTrigger`, `TooltipContent`). Replaced the                                                     
    embedded `TooltipSimple` section with a cross-link to the new page.                                                   
  - Renamed the story category from `Composed Components/Tooltip/TooltipSimple`
    to `Composed Components/TooltipSimple` — removes the double-nesting                                                   
    in the sidebar.                                                                                                       
  - Added `tooltipContentProps` to the Storybook controls table with an
    accurate type summary and description.                                                                                
                                                                                                                          
  ## Evidence          
                                                                                                                          
               

https://github.com/user-attachments/assets/f3235d10-0694-44be-ac02-f48d3e321773

                                                                                                  
                                                                                                                          
  ## How to test                                                                                                        
                                                                                                                          
  ```bash                                                                                                               
  pnpm --filter docs dev                                                                                                  
                                                                                                                 
  1. Open Storybook → Composed Components > TooltipSimple — should show the
  new dedicated docs page with live demo and Props table.                                                               
  2. Open Primitive Components > Tooltip — should only cover primitive
  composition, with a link at the top pointing to TooltipSimple.
  3. Confirm TooltipSimple no longer appears nested under Tooltip in
  the sidebar.