### PR TITLE
fix(tabs): center prefix/suffix icons in tab triggers

### DIFF
--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -674,3 +674,39 @@ export const DisabledStates: Story = {
 		</div>
 	),
 };
+
+/**
+ * Visual-regression anchor for prefix/suffix icon alignment.
+ *
+ * Icons passed via `prefixIcon` / `suffixIcon` are wrapped in a `.tabs__icon`
+ * element. This story isolates that wrapper so Chromatic captures the icon
+ * staying vertically centered against the label (rather than sitting on the
+ * text baseline). Includes prefix-only, suffix-only, and both-icon triggers.
+ */
+export const IconAlignment: Story = {
+	args: {
+		variant: 'primary',
+		defaultValue: 'prefix',
+		items: [
+			{
+				key: 'prefix',
+				label: 'Prefix Icon',
+				children: 'Tab with a leading icon',
+				prefixIcon: <Settings2 className="size-4" />,
+			},
+			{
+				key: 'suffix',
+				label: 'Suffix Icon',
+				children: 'Tab with a trailing icon',
+				suffixIcon: <History className="size-4" />,
+			},
+			{
+				key: 'both',
+				label: 'Both Icons',
+				children: 'Tab with leading and trailing icons',
+				prefixIcon: <LayoutGrid className="size-4" />,
+				suffixIcon: <Component className="size-4" />,
+			},
+		],
+	},
+};

--- a/packages/ui/src/tabs/index.ts
+++ b/packages/ui/src/tabs/index.ts
@@ -39,6 +39,8 @@
  * | `--tabs-hover-slider-will-change` | `transform, width, opacity` |
  * | `--tabs-hover-slider-z-index` | `0` |
  * | `--tabs-hover-text-color` | `var(--l1-foreground-hover)` |
+ * | `--tabs-icon-align-items` | `center` |
+ * | `--tabs-icon-display` | `inline-flex` |
  * | `--tabs-icon-flex-shrink` | `0` |
  * | `--tabs-list-inner-align-items` | `flex-start` |
  * | `--tabs-list-inner-display` | `inline-flex` |

--- a/packages/ui/src/tabs/tabs.module.scss
+++ b/packages/ui/src/tabs/tabs.module.scss
@@ -298,5 +298,7 @@
 }
 
 .tabs__icon {
+  display: var(--tabs-icon-display, inline-flex);
+  align-items: var(--tabs-icon-align-items, center);
   flex-shrink: var(--tabs-icon-flex-shrink, 0);
 }


### PR DESCRIPTION
## Problem

In `Tabs`, an item's icon (`prefixIcon`, `suffixIcon`, or the disabled `Lock`) is wrapped in `<span className={styles['tabs__icon']}>`. That wrapper was only `flex-shrink: 0`, so it stayed `display: inline`. Its inline `<svg>` then aligned to the **text baseline** (with descender space below it), making the icon sit too high relative to the label — the icon looked vertically misaligned even though the span box itself was centered by the trigger's `align-items: center`.

## Fix

Make the `.tabs__icon` wrapper a centered flex container:

```diff
 .tabs__icon {
+  display: inline-flex;
+  align-items: center;
   flex-shrink: 0;
 }
```

This is the single shared class for all three icon paths in `tabs.tsx` (`prefixIcon`, `suffixIcon`, disabled `Lock`), so the one rule fixes every case. CSS-only — no component/API change.