### PR TITLE
docs(dropdown-menu-simple): add dedicated mdx docs for DropdownMenuSimple

### DIFF
--- a/apps/docs/stories/dropdown-menu-root.mdx
+++ b/apps/docs/stories/dropdown-menu-root.mdx
@@ -1,5 +1,4 @@
-import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
-import * as DropdownStories from './dropdown-menu.stories';
+import { Meta, Controls } from '@storybook/addon-docs/blocks';
 import * as DropdownMenuRootStories from './dropdown-menu-root.stories';
 import * as DropdownMenuPortalStories from './dropdown-menu-portal.stories';
 import * as DropdownMenuTriggerStories from './dropdown-menu-trigger.stories';
@@ -20,82 +19,46 @@ import * as DropdownMenuGroupStories from './dropdown-menu-group.stories';
 import * as DropdownMenuLoadingStories from './dropdown-menu-loading.stories';
 import * as DropdownMenuSearchStories from './dropdown-menu-search.stories';
 
-<Meta of={DropdownStories} />
+<Meta of={DropdownMenuRootStories} />
 
 # DropdownMenu
 
 A versatile dropdown menu component with support for icons, search, nested menus, selection states, and custom styling.
 
-## How to use
+For the quick-start preset, see [DropdownMenuSimple](?path=/docs/composed-components-dropdownmenusimple--docs).
 
-### DropdownMenuSimple (preset)
+## Primitive Composition
 
-Use `DropdownMenuSimple` for a declarative menu configuration. Pass a `menu` object with `items` and an optional trigger:
-
-```tsx
-import { DropdownMenuSimple, type MenuItem } from '@signozhq/ui';
-import { Button } from '@signozhq/ui';
-import { Grid3X3, Link2, Trash2 } from '@signozhq/icons';
-
-const items: MenuItem[] = [
-  {
-    type: 'group',
-    label: 'My Account',
-    children: [
-      { key: 'view', label: 'View', icon: <Grid3X3 /> },
-      { key: 'copy', label: 'Copy link', icon: <Link2 /> },
-      { type: 'divider' },
-      { key: 'delete', label: 'Delete', icon: <Trash2 />, danger: true },
-    ],
-  },
-];
-
-export default function MyComponent() {
-  return (
-    <DropdownMenuSimple menu={{ items }}>
-      <Button variant="outlined">Open</Button>
-    </DropdownMenuSimple>
-  );
-}
-```
-
-<Primary />
-
-## DropdownMenuSimple Props
-
-<Controls of={DropdownStories.Default} />
-
-## Primitive composition
-
-For full control, use the low-level building blocks: `DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuPortal`, `DropdownMenuContent`, `DropdownMenuItem`, `DropdownMenuLabel`, `DropdownMenuSeparator`, `DropdownMenuCheckboxItem`, `DropdownMenuRadioGroup`, `DropdownMenuRadioItem`, `DropdownMenuSub`, `DropdownMenuSubTrigger`, `DropdownMenuSubContent`, `DropdownMenuShortcut`, `DropdownMenuBack`, `DropdownMenuMultiStep`, `DropdownMenuGroup`, `DropdownMenuLoading`, and `DropdownMenuSearch`.
+For full control, compose the low-level building blocks directly:
 
 ```tsx
 import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuShortcut,
+	DropdownMenu,
+	DropdownMenuTrigger,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuSeparator,
+	DropdownMenuShortcut,
+	Button,
 } from '@signozhq/ui';
 
 export default function MyComponent() {
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button>Open menu</Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent>
-        <DropdownMenuItem>
-          Profile
-          <DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
-        </DropdownMenuItem>
-        <DropdownMenuItem>Settings</DropdownMenuItem>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem>Logout</DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button>Open menu</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent>
+				<DropdownMenuItem>
+					Profile
+					<DropdownMenuShortcut>⇧⌘P</DropdownMenuShortcut>
+				</DropdownMenuItem>
+				<DropdownMenuItem>Settings</DropdownMenuItem>
+				<DropdownMenuSeparator />
+				<DropdownMenuItem>Logout</DropdownMenuItem>
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
 }
 ```
 

--- a/apps/docs/stories/dropdown-menu-simple.mdx
+++ b/apps/docs/stories/dropdown-menu-simple.mdx
@@ -1,0 +1,282 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as DropdownMenuSimpleStories from './dropdown-menu-simple.stories';
+
+<Meta of={DropdownMenuSimpleStories} />
+
+# DropdownMenuSimple
+
+Preset that accepts a declarative `menu` configuration and renders a complete dropdown menu. Pass a `menu` object with `items` (and optional `search`/`loading`) instead of composing subcomponents manually.
+
+For full primitive control, see [DropdownMenu](?path=/docs/primitive-components-dropdownmenu-dropdownmenu--docs).
+
+## How to use
+
+```tsx
+import { DropdownMenuSimple, type MenuItem } from '@signozhq/ui';
+import { Button } from '@signozhq/ui';
+import { Grid3X3, Link2, Trash2 } from '@signozhq/icons';
+
+const items: MenuItem[] = [
+	{ key: 'view', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+	{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
+	{ type: 'divider' },
+	{ key: 'delete', label: 'Delete', icon: <Trash2 className="h-4 w-4" />, danger: true },
+];
+
+export default function MyComponent() {
+	return (
+		<DropdownMenuSimple menu={{ items }}>
+			<Button variant="solid" color="secondary">Open</Button>
+		</DropdownMenuSimple>
+	);
+}
+```
+
+<Primary />
+
+## With Icons
+
+Use `icon` for a left icon and `rightIcon` for a right icon on any item:
+
+```tsx
+import { Grid3X3, Link2, Check, Trash2 } from '@signozhq/icons';
+
+const items: MenuItem[] = [
+	{ key: 'view', label: 'View', icon: <Grid3X3 className="h-4 w-4" />, rightIcon: <Check className="h-4 w-4" /> },
+	{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
+	{ type: 'divider' },
+	{ key: 'delete', label: 'Delete dashboard', icon: <Trash2 className="h-4 w-4" />, danger: true },
+];
+
+<DropdownMenuSimple menu={{ items }}>
+	<Button variant="solid" color="secondary">View Options</Button>
+</DropdownMenuSimple>
+```
+
+## Destructive Items
+
+Set `danger: true` on any item to style it as a destructive action:
+
+```tsx
+const items: MenuItem[] = [
+	{ key: 'view', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+	{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
+	{ type: 'divider' },
+	{ key: 'delete', label: 'Delete dashboard', icon: <Trash2 className="h-4 w-4" />, danger: true },
+];
+```
+
+## Section Labels
+
+Wrap items in a `type: 'group'` to add a label header and visually separate related actions:
+
+```tsx
+import { User, Settings, LogOut } from '@signozhq/icons';
+
+const items: MenuItem[] = [
+	{
+		type: 'group',
+		label: 'My Account',
+		children: [
+			{ key: 'profile', label: 'Profile', icon: <User className="h-4 w-4" /> },
+			{ key: 'settings', label: 'Settings', icon: <Settings className="h-4 w-4" /> },
+			{ type: 'divider' },
+			{ key: 'logout', label: 'Log out', icon: <LogOut className="h-4 w-4" />, danger: true },
+		],
+	},
+];
+```
+
+## Keyboard Shortcuts
+
+Add `shortcut` to display a keyboard hint on the right side of an item:
+
+```tsx
+const items: MenuItem[] = [
+	{ key: 'profile', label: 'Profile', shortcut: '⇧⌘P' },
+	{ key: 'billing', label: 'Billing', shortcut: '⌘B' },
+	{ key: 'settings', label: 'Settings', shortcut: '⌘S' },
+	{ type: 'divider' },
+	{ key: 'logout', label: 'Log out', danger: true, shortcut: '⇧⌘Q' },
+];
+```
+
+## Checkable Items
+
+Use `type: 'checkbox'` for togglable items and `type: 'radio-group'` for single-selection groups:
+
+```tsx
+import { useState } from 'react';
+
+function MyComponent() {
+	const [showPanel, setShowPanel] = useState(false);
+	const [position, setPosition] = useState('bottom');
+
+	const items: MenuItem[] = [
+		{
+			type: 'group',
+			label: 'Appearance',
+			children: [
+				{
+					type: 'checkbox',
+					key: 'panel',
+					label: 'Show Panel',
+					checked: showPanel,
+					onCheckedChange: setShowPanel,
+				},
+			],
+		},
+		{
+			type: 'group',
+			label: 'Panel Position',
+			children: [
+				{
+					type: 'radio-group',
+					value: position,
+					onChange: setPosition,
+					children: [
+						{ type: 'radio', key: 'top', label: 'Top', value: 'top' },
+						{ type: 'radio', key: 'bottom', label: 'Bottom', value: 'bottom' },
+						{ type: 'radio', key: 'right', label: 'Right', value: 'right' },
+					],
+				},
+			],
+		},
+	];
+
+	return (
+		<DropdownMenuSimple menu={{ items }}>
+			<Button>View Settings</Button>
+		</DropdownMenuSimple>
+	);
+}
+```
+
+## Nested Menus
+
+Add `children` to any item to create a submenu. Submenus open on hover and display a chevron indicator automatically:
+
+```tsx
+import { User, Copy, Link2 } from '@signozhq/icons';
+
+const items: MenuItem[] = [
+	{
+		key: 'invite',
+		label: 'Invite users',
+		icon: <User className="h-4 w-4" />,
+		children: [
+			{ key: 'email', label: 'Email', icon: <Copy className="h-4 w-4" /> },
+			{ key: 'message', label: 'Message', icon: <Link2 className="h-4 w-4" /> },
+			{ type: 'divider' },
+			{ key: 'more', label: 'More...' },
+		],
+	},
+	{ key: 'settings', label: 'Settings' },
+];
+```
+
+## Loading State
+
+Pass `loading: true` to show a spinner while items are being fetched. Use `loading: { text: '...' }` to customise the loading message:
+
+```tsx
+<DropdownMenuSimple menu={{ items: [], loading: true }}>
+	<Button>Loading Menu</Button>
+</DropdownMenuSimple>
+
+// With custom text
+<DropdownMenuSimple menu={{ items: [], loading: { text: 'Fetching options...' } }}>
+	<Button>Loading Menu</Button>
+</DropdownMenuSimple>
+```
+
+## With Search
+
+Pass `menu.search` to render a search input at the top of the menu. Use `onSearchChange` to filter the items array based on the current query:
+
+```tsx
+import { useMemo, useState } from 'react';
+import { Search, User, Settings } from '@signozhq/icons';
+
+const allItems: MenuItem[] = [
+	{ key: 'profile', label: 'Profile', icon: <User className="h-4 w-4" /> },
+	{ key: 'settings', label: 'Settings', icon: <Settings className="h-4 w-4" /> },
+	{ key: 'billing', label: 'Billing' },
+	{ type: 'divider' },
+	{ key: 'logout', label: 'Log out', danger: true },
+];
+
+function SearchableMenu() {
+	const [query, setQuery] = useState('');
+
+	const filteredItems = useMemo(() => {
+		if (!query.trim()) return allItems;
+		const q = query.toLowerCase();
+		return allItems.filter((item) => {
+			if ('type' in item && item.type === 'divider') return true;
+			return 'label' in item && String(item.label).toLowerCase().includes(q);
+		});
+	}, [query]);
+
+	return (
+		<DropdownMenuSimple
+			menu={{
+				items: filteredItems,
+				search: {
+					placeholder: 'Search menu...',
+					searchIcon: <Search className="h-4 w-4" />,
+					onSearchChange: setQuery,
+				},
+			}}
+		>
+			<Button>Search Menu</Button>
+		</DropdownMenuSimple>
+	);
+}
+```
+
+Keyboard navigation: `ArrowDown` from the search input moves focus to the first menu item. `ArrowUp` or `Shift+Tab` from the first item returns focus to the search input.
+
+## Handling Selection
+
+Add `onSelect` to any item to respond when it is clicked or activated via keyboard:
+
+```tsx
+const items: MenuItem[] = [
+	{ key: 'view', label: 'View', onSelect: () => console.log('view') },
+	{ key: 'copy', label: 'Copy link', onSelect: () => navigator.clipboard.writeText(url) },
+	{ type: 'divider' },
+	{ key: 'delete', label: 'Delete', danger: true, onSelect: () => handleDelete() },
+];
+```
+
+Use `disabled: true` to prevent selection without removing the item from the list:
+
+```tsx
+const items: MenuItem[] = [
+	{ key: 'edit', label: 'Edit' },
+	{ key: 'publish', label: 'Publish', disabled: true },
+];
+```
+
+## Positioning
+
+`side` sets which side of the trigger the menu opens against. `align` controls alignment along that side. Collision detection automatically repositions the menu when it would overflow the viewport:
+
+```tsx
+<DropdownMenuSimple menu={{ items }} side="right" align="start">
+	<Button>Open</Button>
+</DropdownMenuSimple>
+```
+
+Use `sideOffset` and `alignOffset` for pixel-level adjustments:
+
+```tsx
+<DropdownMenuSimple menu={{ items }} side="bottom" sideOffset={8} alignOffset={4}>
+	<Button>Open</Button>
+</DropdownMenuSimple>
+```
+
+## Props
+
+<Controls of={DropdownMenuSimpleStories.Default} />

--- a/apps/docs/stories/dropdown-menu-simple.stories.tsx
+++ b/apps/docs/stories/dropdown-menu-simple.stories.tsx
@@ -18,13 +18,11 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useMemo, useState } from 'react';
 
 const meta: Meta<typeof DropdownMenuSimple> = {
-	title: 'Composed Components/DropdownMenu/DropdownMenuSimple',
+	title: 'Composed Components/DropdownMenuSimple',
 	component: DropdownMenuSimple,
 	parameters: {
 		layout: 'fullscreen',
-		backgrounds: {
-			disable: true,
-		},
+		backgrounds: { default: 'dark' },
 	},
 	argTypes: {
 		menu: {
@@ -123,42 +121,6 @@ export const Default: Story = {
 	),
 };
 
-export const Playground: Story = {
-	args: {
-		menu: {
-			items: [
-				{
-					type: 'group',
-					label: 'My Account',
-					children: [
-						{ key: 'view', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-						{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
-						{ type: 'divider' },
-						{
-							key: 'delete',
-							label: 'Delete',
-							icon: <Trash2 className="h-4 w-4" />,
-							danger: true,
-						},
-					],
-				},
-			],
-		},
-		align: 'start',
-		side: 'bottom',
-		sideOffset: 4,
-	},
-	render: (args) => (
-		<div className="p-8">
-			<DropdownMenuSimple {...args}>
-				<Button variant="solid" color="secondary">
-					Open
-				</Button>
-			</DropdownMenuSimple>
-		</div>
-	),
-};
-
 // Basic DropdownMenuSimple
 export const Basic: Story = {
 	parameters: {
@@ -220,9 +182,9 @@ export const WithIcons: Story = {
 		const items1: MenuItem[] = [
 			{ key: 'view', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
 			{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
-			{ key: 'view2', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view3', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view4', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+			{ key: 'open', label: 'Open', icon: <FileText className="h-4 w-4" /> },
+			{ key: 'duplicate', label: 'Duplicate', icon: <Copy className="h-4 w-4" /> },
+			{ key: 'archive', label: 'Archive', icon: <Folder className="h-4 w-4" /> },
 			{ type: 'divider' },
 			{
 				key: 'delete',
@@ -240,9 +202,9 @@ export const WithIcons: Story = {
 				rightIcon: <Check className="h-4 w-4" />,
 			},
 			{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
-			{ key: 'view2', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view3', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view4', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+			{ key: 'open', label: 'Open', icon: <FileText className="h-4 w-4" /> },
+			{ key: 'duplicate', label: 'Duplicate', icon: <Copy className="h-4 w-4" /> },
+			{ key: 'archive', label: 'Archive', icon: <Folder className="h-4 w-4" /> },
 		];
 
 		const items3: MenuItem[] = [
@@ -253,9 +215,9 @@ export const WithIcons: Story = {
 				rightIcon: <ChevronRight className="h-4 w-4" />,
 			},
 			{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
-			{ key: 'view2', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view3', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-			{ key: 'view4', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+			{ key: 'open', label: 'Open', icon: <FileText className="h-4 w-4" /> },
+			{ key: 'duplicate', label: 'Duplicate', icon: <Copy className="h-4 w-4" /> },
+			{ key: 'archive', label: 'Archive', icon: <Folder className="h-4 w-4" /> },
 			{ type: 'divider' },
 			{
 				key: 'delete',
@@ -363,9 +325,9 @@ export const WithSectionLabels: Story = {
 						rightIcon: <Check className="h-4 w-4" />,
 					},
 					{ key: 'copy', label: 'Copy link', icon: <Link2 className="h-4 w-4" /> },
-					{ key: 'view2', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-					{ key: 'view3', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
-					{ key: 'view4', label: 'View', icon: <Grid3X3 className="h-4 w-4" /> },
+					{ key: 'open', label: 'Open', icon: <FileText className="h-4 w-4" /> },
+					{ key: 'duplicate', label: 'Duplicate', icon: <Copy className="h-4 w-4" /> },
+					{ key: 'archive', label: 'Archive', icon: <Folder className="h-4 w-4" /> },
 					{ type: 'divider' },
 					{
 						key: 'delete',
@@ -642,7 +604,6 @@ export const WithSearch: Story = {
 			if (!query.trim()) return searchMenuItems;
 			const q = query.toLowerCase();
 			return searchMenuItems.filter((item) => {
-				// Dividers are kept but will be cleaned up by DropdownMenuSimple's cleanupMenuItems
 				if ('type' in item && item.type === 'divider') return true;
 				return 'label' in item && String(item.label).toLowerCase().includes(q);
 			});
@@ -742,7 +703,7 @@ export const AllStates: Story = {
 				key: 'new-team',
 				label: 'New Team',
 				icon: <Folder className="h-4 w-4" />,
-				shortcut: '⌘+T',
+				shortcut: '⌘T',
 			},
 			{ type: 'divider' },
 			{ key: 'github', label: 'GitHub', icon: <Link2 className="h-4 w-4" /> },


### PR DESCRIPTION
Closes #284                                                                                                            
                                                                                                                  
  ## Changes                                                                                                             
                                                                                                                       
  - Added `dropdown-menu-simple.mdx` — a dedicated Storybook docs page for
    `DropdownMenuSimple` with sections for basic usage, icons, destructive                                             
    loading state, search, selection handling, positioning, and a live Props table.
  - Renamed `dropdown-menu.mdx` → `dropdown-menu-root.mdx` to focus solely on                                            
    primitive composition (`DropdownMenu`, `DropdownMenuTrigger`, `DropdownMenuContent`,
    and all sub-components). Added a cross-link to the new `DropdownMenuSimple` page.                                    
  - Renamed `dropdown-menu.stories.tsx` → `dropdown-menu-simple.stories.tsx` and                                         
    changed the story category from `Composed Components/DropdownMenu/DropdownMenuSimple`                                
    to `Composed Components/DropdownMenuSimple` — removes the double-nesting in the sidebar.                             
  - Replaced duplicate menu item keys (`view2`, `view3`, `view4`) with meaningful                                        
    labels (`open`, `duplicate`, `archive`) across stories.                                                              
  - Fixed shortcut format from `⌘+T` to `⌘T` to be consistent with all other shortcuts.                                  
                                                                                                                         
  ## Evidence                                                                                                            
                                                                                                                         
             

https://github.com/user-attachments/assets/bcce8099-68a3-4277-8317-f82d0eb33d5d

                                       
                                                                                                                         
  ## How to test                                                                                                         
                                                                                                                         
  pnpm --filter docs dev                                                                                                 
                                                                                                                       
  1. Open Storybook → Composed Components > DropdownMenuSimple — should                                                  
     show the new dedicated docs page with live demo and Props table.                                             
  2. Open Primitive Components > DropdownMenu > DropdownMenu — should only
     cover primitives, with a link at the top pointing to DropdownMenuSimple.                                          
  3. Confirm DropdownMenuSimple no longer appears nested under DropdownMenu                                              
     in the sidebar.                          
                       