### PR TITLE
docs(pagination): add dedicated mdx docs for Pagination, PaginationUrl, and PaginationContainer

### DIFF
--- a/apps/docs/stories/pagination-container.mdx
+++ b/apps/docs/stories/pagination-container.mdx
@@ -1,0 +1,171 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as PaginationContainerStories from './pagination-container.stories';
+import * as PaginationContentStories from './pagination-content.stories';
+import * as PaginationItemStories from './pagination-item.stories';
+import * as PaginationLinkStories from './pagination-link.stories';
+import * as PaginationPreviousStories from './pagination-previous.stories';
+import * as PaginationNextStories from './pagination-next.stories';
+import * as PaginationEllipsisStories from './pagination-ellipsis.stories';
+import * as PaginationSelectorStories from './pagination-selector.stories';
+
+<Meta of={PaginationContainerStories} />
+
+# PaginationContainer
+
+Low-level building blocks for constructing fully custom pagination layouts.
+
+For the all-in-one preset, see [Pagination](?path=/docs/composed-components-pagination--docs). For URL-synchronized pagination, see [PaginationUrl](?path=/docs/composed-components-paginationurl--docs).
+
+<Primary />
+
+## Primitive composition
+
+Compose the primitives for full control:
+
+```tsx
+import {
+	PaginationContainer,
+	PaginationContent,
+	PaginationItem,
+	PaginationLink,
+	PaginationPrevious,
+	PaginationNext,
+	PaginationEllipsis,
+} from '@signozhq/ui';
+import { useState } from 'react';
+
+export default function MyComponent() {
+	const [current, setCurrent] = useState(1);
+	const totalPages = 10;
+
+	return (
+		<PaginationContainer align="center">
+			<PaginationContent>
+				<PaginationItem>
+					<PaginationPrevious
+						onClick={() => setCurrent((p) => Math.max(1, p - 1))}
+						disabled={current === 1}
+					/>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationLink isActive={current === 1} onClick={() => setCurrent(1)}>
+						1
+					</PaginationLink>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationEllipsis />
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationLink
+						isActive={current === totalPages}
+						onClick={() => setCurrent(totalPages)}
+					>
+						{totalPages}
+					</PaginationLink>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationNext
+						onClick={() => setCurrent((p) => Math.min(totalPages, p + 1))}
+						disabled={current === totalPages}
+					/>
+				</PaginationItem>
+			</PaginationContent>
+		</PaginationContainer>
+	);
+}
+```
+
+## With page size selector
+
+Add `PaginationSelector` alongside `PaginationContent` to let users control page size:
+
+```tsx
+import {
+	PaginationContainer,
+	PaginationContent,
+	PaginationItem,
+	PaginationLink,
+	PaginationPrevious,
+	PaginationNext,
+	PaginationSelector,
+} from '@signozhq/ui';
+import { useState } from 'react';
+
+export default function MyComponent() {
+	const [current, setCurrent] = useState(1);
+	const [pageSize, setPageSize] = useState(10);
+	const totalPages = Math.ceil(100 / pageSize);
+
+	return (
+		<PaginationContainer align="center">
+			<PaginationSelector
+				value={pageSize}
+				options={[10, 20, 50]}
+				onChange={(size) => {
+					setPageSize(size);
+					setCurrent(1);
+				}}
+			/>
+			<PaginationContent>
+				<PaginationItem>
+					<PaginationPrevious
+						onClick={() => setCurrent((p) => Math.max(1, p - 1))}
+						disabled={current === 1}
+					/>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationLink isActive={current === 1} onClick={() => setCurrent(1)}>
+						1
+					</PaginationLink>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationLink
+						isActive={current === totalPages}
+						onClick={() => setCurrent(totalPages)}
+					>
+						{totalPages}
+					</PaginationLink>
+				</PaginationItem>
+				<PaginationItem>
+					<PaginationNext
+						onClick={() => setCurrent((p) => Math.min(totalPages, p + 1))}
+						disabled={current === totalPages}
+					/>
+				</PaginationItem>
+			</PaginationContent>
+		</PaginationContainer>
+	);
+}
+```
+
+## PaginationContainer Props
+
+<Controls of={PaginationContainerStories.Default} />
+
+## PaginationContent Props
+
+<Controls of={PaginationContentStories.Default} />
+
+## PaginationItem Props
+
+<Controls of={PaginationItemStories.Default} />
+
+## PaginationLink Props
+
+<Controls of={PaginationLinkStories.Default} />
+
+## PaginationPrevious Props
+
+<Controls of={PaginationPreviousStories.Default} />
+
+## PaginationNext Props
+
+<Controls of={PaginationNextStories.Default} />
+
+## PaginationEllipsis Props
+
+<Controls of={PaginationEllipsisStories.Default} />
+
+## PaginationSelector Props
+
+<Controls of={PaginationSelectorStories.Default} />

--- a/apps/docs/stories/pagination-selector.stories.tsx
+++ b/apps/docs/stories/pagination-selector.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useEffect, useState } from 'react';
 
 const meta: Meta<typeof PaginationSelector> = {
-	title: 'Components/Pagination/PaginationSelector',
+	title: 'Primitive Components/Pagination/PaginationSelector',
 	component: PaginationSelector,
 	argTypes: {
 		label: {

--- a/apps/docs/stories/pagination-url.mdx
+++ b/apps/docs/stories/pagination-url.mdx
@@ -1,0 +1,74 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as PaginationUrlStories from './pagination-url.stories';
+
+<Meta of={PaginationUrlStories} />
+
+# PaginationUrl
+
+URL-driven pagination preset that synchronizes the current page with a browser query parameter using [nuqs](https://nuqs.dev/). Useful for deep-linking and coordinating with browser back/forward navigation.
+
+For state-managed pagination, see [Pagination](?path=/docs/composed-components-pagination--docs). For full primitive control, see [Pagination primitives](?path=/docs/primitive-components-pagination-paginationcontainer--docs).
+
+## How to use
+
+> Requires [nuqs](https://nuqs.dev/). Wrap your app (or the relevant subtree) in the appropriate `NuqsAdapter`.
+
+```tsx
+import { PaginationUrl } from '@signozhq/ui';
+import { NuqsAdapter } from 'nuqs/adapters/react';
+
+export default function MyComponent() {
+	return (
+		<NuqsAdapter>
+			<PaginationUrl
+				urlKey="page"
+				total={100}
+				pageSize={10}
+			/>
+		</NuqsAdapter>
+	);
+}
+```
+
+<Primary />
+
+## Custom URL key
+
+Use a unique `urlKey` per component instance to avoid query-parameter conflicts when multiple paginations appear on the same page:
+
+```tsx
+<PaginationUrl urlKey="logs-page" total={500} pageSize={25} />
+<PaginationUrl urlKey="events-page" total={200} pageSize={10} />
+```
+
+## With page size selector
+
+Add `enablePageSize` to surface a page size dropdown alongside the pagination controls:
+
+```tsx
+<PaginationUrl
+	urlKey="page"
+	total={100}
+	pageSize={10}
+	enablePageSize
+/>
+```
+
+Position the selector on the left with `pageSizePosition`:
+
+```tsx
+<PaginationUrl urlKey="page" total={100} enablePageSize pageSizePosition="left" />
+```
+
+## Custom page size URL key
+
+When `enablePageSize` is true, the selected page size is also stored in the URL. Use `pageSizeUrlKey` to customize that query parameter — required when multiple `PaginationUrl` instances share a page so their size keys don't collide:
+
+```tsx
+<PaginationUrl urlKey="logs-page" pageSizeUrlKey="logs-size" total={500} pageSize={25} enablePageSize />
+<PaginationUrl urlKey="events-page" pageSizeUrlKey="events-size" total={200} pageSize={10} enablePageSize />
+```
+
+## Props
+
+<Controls of={PaginationUrlStories.Default} />

--- a/apps/docs/stories/pagination-url.stories.tsx
+++ b/apps/docs/stories/pagination-url.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { NuqsAdapter } from 'nuqs/adapters/react';
 
 const meta: Meta<typeof PaginationUrl> = {
-	title: 'Composed Components/Pagination/PaginationUrl',
+	title: 'Composed Components/PaginationUrl',
 	component: PaginationUrl,
 	argTypes: {
 		urlKey: {
@@ -63,6 +63,25 @@ const meta: Meta<typeof PaginationUrl> = {
 				defaultValue: { summary: '[10, 20, 30, 40, 50]' },
 			},
 		},
+		pageSizePosition: {
+			control: 'select',
+			options: ['left', 'right'],
+			description: 'Position of the page size selector relative to pagination controls',
+			table: {
+				category: 'Behavior',
+				type: { summary: "'left' | 'right'" },
+				defaultValue: { summary: "'right'" },
+			},
+		},
+		pageSizeUrlKey: {
+			control: 'text',
+			description: 'Query parameter key for the page size in the URL',
+			table: {
+				category: 'Behavior',
+				type: { summary: 'string' },
+				defaultValue: { summary: "'pageSize'" },
+			},
+		},
 		onPageSizeChange: {
 			control: false,
 			description: 'Callback when the page size changes',
@@ -116,6 +135,24 @@ export const WithPageSizeSelector: Story = {
 		total: 100,
 		pageSize: 10,
 		enablePageSize: true,
+		align: 'start',
+	},
+	decorators: [
+		(Story) => (
+			<NuqsAdapter>
+				<Story />
+			</NuqsAdapter>
+		),
+	],
+};
+
+export const WithPageSizeSelectorLeft: Story = {
+	args: {
+		urlKey: 'page',
+		total: 100,
+		pageSize: 10,
+		enablePageSize: true,
+		pageSizePosition: 'left',
 		align: 'start',
 	},
 	decorators: [

--- a/apps/docs/stories/pagination.mdx
+++ b/apps/docs/stories/pagination.mdx
@@ -1,26 +1,15 @@
 import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
 import * as PaginationStories from './pagination.stories';
-import * as PaginationUrlStories from './pagination-url.stories';
-import * as PaginationContainerStories from './pagination-container.stories';
-import * as PaginationContentStories from './pagination-content.stories';
-import * as PaginationItemStories from './pagination-item.stories';
-import * as PaginationLinkStories from './pagination-link.stories';
-import * as PaginationPreviousStories from './pagination-previous.stories';
-import * as PaginationNextStories from './pagination-next.stories';
-import * as PaginationEllipsisStories from './pagination-ellipsis.stories';
-import * as PaginationSelectorStories from './pagination-selector.stories';
 
 <Meta of={PaginationStories} />
 
 # Pagination
 
-A flexible pagination component for navigating through multi-page content.
+All-in-one pagination component that renders previous/next buttons and page numbers automatically. Supports controlled and uncontrolled usage, alignment, and an optional page size selector.
+
+For URL-synchronized pagination, see [PaginationUrl](?path=/docs/composed-components-paginationurl--docs). For full primitive control, see [Pagination primitives](?path=/docs/primitive-components-pagination-paginationcontainer--docs).
 
 ## How to use
-
-### Pagination (all-in-one)
-
-Use `Pagination` for standard pagination with minimal setup. It renders previous/next buttons and page numbers automatically.
 
 ```tsx
 import { Pagination } from '@signozhq/ui';
@@ -35,160 +24,71 @@ export default function MyComponent() {
 			pageSize={10}
 			current={currentPage}
 			onPageChange={(page) => setCurrentPage(page)}
-			align="center"
 		/>
 	);
 }
 ```
 
-Uncontrolled usage:
+<Primary />
+
+## Uncontrolled usage
+
+Use `defaultCurrent` when you don't need to track the page externally:
 
 ```tsx
 <Pagination total={100} pageSize={10} defaultCurrent={1} />
 ```
 
-With page size selector (defaults to the right side):
+## Alignment
+
+Control horizontal alignment with the `align` prop:
 
 ```tsx
-<Pagination total={100} enablePageSize />
+<Pagination total={100} pageSize={10} align="center" />
+<Pagination total={100} pageSize={10} align="end" />
 ```
 
-With page size selector on the left:
+## With page size selector
+
+Enable the page size dropdown with `enablePageSize`. It renders on the right by default:
+
+```tsx
+import { Pagination } from '@signozhq/ui';
+import { useState } from 'react';
+
+export default function MyComponent() {
+	const [currentPage, setCurrentPage] = useState(1);
+	const [pageSize, setPageSize] = useState(10);
+
+	return (
+		<Pagination
+			total={100}
+			pageSize={pageSize}
+			current={currentPage}
+			onPageChange={setCurrentPage}
+			enablePageSize
+			onPageSizeChange={setPageSize}
+		/>
+	);
+}
+```
+
+Position the selector on the left:
 
 ```tsx
 <Pagination total={100} enablePageSize pageSizePosition="left" />
 ```
 
-<Primary />
-
-## Pagination Props
-
-<Controls of={PaginationStories.Default} />
-
-## PaginationUrl
-
-URL-driven pagination that synchronizes the current page with a query parameter using `nuqs`. Useful for deep-linking or coordinating with browser back/forward.
-
-> This component requires setup with [nuqs](https://nuqs.dev/).
+Custom page size options:
 
 ```tsx
-import { PaginationUrl } from '@signozhq/ui';
-import { NuqsAdapter } from 'nuqs/adapters/react';
-
-export default function MyComponent() {
-	return (
-		<NuqsAdapter>
-			<PaginationUrl
-				urlKey="page"
-				total={100}
-				pageSize={10}
-				align="center"
-			/>
-		</NuqsAdapter>
-	);
-}
-```
-
-With custom `urlKey` to avoid conflicts:
-
-```tsx
-<PaginationUrl
-	urlKey="logs-page"
-	total={500}
-	pageSize={25}
-	align="center"
+<Pagination
+	total={100}
+	enablePageSize
+	pageSizeOptions={[5, 10, 25, 50]}
 />
 ```
 
-## PaginationUrl Props
+## Props
 
-<Controls of={PaginationUrlStories.Default} />
-
-## Primitive composition
-
-For full control, use the low-level building blocks: `PaginationContainer`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`, and `PaginationSelector`.
-
-```tsx
-import {
-	PaginationContainer,
-	PaginationContent,
-	PaginationItem,
-	PaginationLink,
-	PaginationPrevious,
-	PaginationNext,
-	PaginationEllipsis,
-} from '@signozhq/ui';
-import { useState } from 'react';
-
-export default function MyComponent() {
-	const [current, setCurrent] = useState(1);
-	const totalPages = 10;
-
-	return (
-		<PaginationContainer align="center">
-			<PaginationContent>
-				<PaginationItem>
-					<PaginationPrevious
-						onClick={() => setCurrent((p) => Math.max(1, p - 1))}
-						disabled={current === 1}
-					/>
-				</PaginationItem>
-				<PaginationItem>
-					<PaginationLink isActive={current === 1} onClick={() => setCurrent(1)}>
-						1
-					</PaginationLink>
-				</PaginationItem>
-				<PaginationItem>
-					<PaginationEllipsis />
-				</PaginationItem>
-				<PaginationItem>
-					<PaginationLink
-						isActive={current === totalPages}
-						onClick={() => setCurrent(totalPages)}
-					>
-						{totalPages}
-					</PaginationLink>
-				</PaginationItem>
-				<PaginationItem>
-					<PaginationNext
-						onClick={() => setCurrent((p) => Math.min(totalPages, p + 1))}
-						disabled={current === totalPages}
-					/>
-				</PaginationItem>
-			</PaginationContent>
-		</PaginationContainer>
-	);
-}
-```
-
-## PaginationContainer Props
-
-<Controls of={PaginationContainerStories.Default} />
-
-## PaginationContent Props
-
-<Controls of={PaginationContentStories.Default} />
-
-## PaginationItem Props
-
-<Controls of={PaginationItemStories.Default} />
-
-## PaginationLink Props
-
-<Controls of={PaginationLinkStories.Default} />
-
-## PaginationPrevious Props
-
-<Controls of={PaginationPreviousStories.Default} />
-
-## PaginationNext Props
-
-<Controls of={PaginationNextStories.Default} />
-
-## PaginationEllipsis Props
-
-<Controls of={PaginationEllipsisStories.Default} />
-
-## PaginationSelector Props
-
-<Controls of={PaginationSelectorStories.Default} />
+<Controls of={PaginationStories.Default} />

--- a/apps/docs/stories/pagination.stories.tsx
+++ b/apps/docs/stories/pagination.stories.tsx
@@ -5,7 +5,10 @@ import { useEffect, useState } from 'react';
 
 type PaginationProps = ComponentProps<typeof Pagination>;
 
-const ControlledPagination = (args: PaginationProps, initialPage: number): JSX.Element => {
+function ControlledPagination({
+	initialPage,
+	...args
+}: PaginationProps & { initialPage: number }): JSX.Element {
 	const [currentPage, setCurrentPage] = useState(args.current ?? initialPage);
 
 	useEffect(() => {
@@ -24,10 +27,10 @@ const ControlledPagination = (args: PaginationProps, initialPage: number): JSX.E
 			}}
 		/>
 	);
-};
+}
 
 const meta: Meta<typeof Pagination> = {
-	title: 'Composed Components/Pagination/Pagination',
+	title: 'Composed Components/Pagination',
 	component: Pagination,
 	argTypes: {
 		total: {
@@ -233,17 +236,7 @@ export const CenterAligned: Story = {
 		pageSize: 10,
 		align: 'center',
 	},
-	render: (args) => {
-		const [current, setCurrent] = useState(args.current ?? 1);
-
-		useEffect(() => {
-			if (args.current !== undefined) {
-				setCurrent(args.current);
-			}
-		}, [args.current]);
-
-		return <Pagination {...args} current={current} onPageChange={setCurrent} />;
-	},
+	render: (args) => <ControlledPagination {...args} initialPage={1} />,
 };
 
 export const EndAligned: Story = {
@@ -252,17 +245,7 @@ export const EndAligned: Story = {
 		pageSize: 10,
 		align: 'end',
 	},
-	render: (args) => {
-		const [current, setCurrent] = useState(args.current ?? 1);
-
-		useEffect(() => {
-			if (args.current !== undefined) {
-				setCurrent(args.current);
-			}
-		}, [args.current]);
-
-		return <Pagination {...args} current={current} onPageChange={setCurrent} />;
-	},
+	render: (args) => <ControlledPagination {...args} initialPage={1} />,
 };
 
 export const CustomPageSize: Story = {
@@ -270,17 +253,7 @@ export const CustomPageSize: Story = {
 		total: 100,
 		pageSize: 5,
 	},
-	render: (args) => {
-		const [current, setCurrent] = useState(args.current ?? 1);
-
-		useEffect(() => {
-			if (args.current !== undefined) {
-				setCurrent(args.current);
-			}
-		}, [args.current]);
-
-		return <Pagination {...args} current={current} onPageChange={setCurrent} />;
-	},
+	render: (args) => <ControlledPagination {...args} initialPage={1} />,
 };
 
 export const WithPageChangeHandler: Story = {
@@ -310,32 +283,32 @@ export const WithPageChangeHandler: Story = {
 	},
 };
 
-export const ThreePages_FirstSelected: Story = {
+export const ThreePagesFirstSelected: Story = {
 	args: {
 		total: 30,
 	},
-	render: (args) => ControlledPagination(args, 1),
+	render: (args) => <ControlledPagination {...args} initialPage={1} />,
 };
 
-export const ThreePages_SecondSelected: Story = {
+export const ThreePagesSecondSelected: Story = {
 	args: {
 		total: 30,
 	},
-	render: (args) => ControlledPagination(args, 2),
+	render: (args) => <ControlledPagination {...args} initialPage={2} />,
 };
 
-export const TenPages_FirstSelected: Story = {
+export const TenPagesFirstSelected: Story = {
 	args: {
 		total: 100,
 	},
-	render: (args) => ControlledPagination(args, 1),
+	render: (args) => <ControlledPagination {...args} initialPage={1} />,
 };
 
-export const TenPages_LastSelected: Story = {
+export const TenPagesLastSelected: Story = {
 	args: {
 		total: 100,
 	},
-	render: (args) => ControlledPagination(args, 10),
+	render: (args) => <ControlledPagination {...args} initialPage={10} />,
 };
 
 export const WithPageSizeSelector: Story = {


### PR DESCRIPTION
Closes #285

## Changes

- Added `pagination-url.mdx` — dedicated Storybook docs page for `PaginationUrl` with sections for NuqsAdapter setup, custom URL keys, page size selector usage, and custom `pageSizeUrlKey` for multi-instance pages.
- Added `pagination-container.mdx` — dedicated Storybook docs page for the pagination primitives (`PaginationContainer`, `PaginationContent`, `PaginationItem`, `PaginationLink`, `PaginationPrevious`, `PaginationNext`, `PaginationEllipsis`, `PaginationSelector`) with full composition examples and individual Props tables.
- Rewrote `pagination.mdx` to focus solely on the `Pagination` composed component. Added cross-links to the new `PaginationUrl` and `PaginationContainer` pages.
- Changed `pagination.stories.tsx` title from `Composed Components/Pagination/Pagination` to `Composed Components/Pagination` — removes double-nesting in the sidebar. Converted `ControlledPagination` from a non-JSX function call pattern to a proper React component. Renamed stories (`ThreePages_FirstSelected` → `ThreePagesFirstSelected`, etc.).
- Changed `pagination-url.stories.tsx` title from `Composed Components/Pagination/PaginationUrl` to `Composed Components/PaginationUrl`. Added missing `pageSizePosition`, `pageSizeUrlKey`, and `onPageSizeChange` argTypes. Added `WithPageSizeSelectorLeft` story.
- Changed `pagination-selector.stories.tsx` title from `Components/Pagination/PaginationSelector` to `Primitive Components/Pagination/PaginationSelector`.

## Evidence


https://github.com/user-attachments/assets/28553c0d-3675-4289-affc-1b21814ae947


## How to test

```
pnpm --filter docs dev
```

1. Open Storybook → **Composed Components > Pagination** — should show the focused docs page with controlled/uncontrolled usage, alignment, and page size selector examples, plus cross-links at the top.
2. Open **Composed Components > PaginationUrl** — should show the new dedicated docs page covering `NuqsAdapter` setup, custom `urlKey`, and `pageSizeUrlKey` examples.
3. Open **Primitive Components > Pagination > PaginationContainer** — should show the new dedicated docs with full primitive composition examples and all sub-component Props tables.
4. Confirm none of the three are nested under each other in the sidebar.