### PR TITLE
docs(tabs): add dedicated mdx docs for TabsSimple

### DIFF
--- a/apps/docs/stories/tabs-list.stories.tsx
+++ b/apps/docs/stories/tabs-list.stories.tsx
@@ -36,6 +36,16 @@ const meta: Meta<typeof TabsList> = {
 				defaultValue: { summary: "'left'" },
 			},
 		},
+		leftContent: {
+			control: false,
+			description: 'Content rendered to the left of the tab list, in the same horizontal row.',
+			table: { category: 'Content', type: { summary: 'React.ReactNode' } },
+		},
+		rightContent: {
+			control: false,
+			description: 'Content rendered to the right of the tab list, in the same horizontal row.',
+			table: { category: 'Content', type: { summary: 'React.ReactNode' } },
+		},
 		id: {
 			control: 'text',
 			description: 'A unique identifier for the tabs list.',

--- a/apps/docs/stories/tabs-root.mdx
+++ b/apps/docs/stories/tabs-root.mdx
@@ -1,0 +1,54 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as TabsRootStories from './tabs-root.stories';
+import * as TabsListStories from './tabs-list.stories';
+import * as TabsTriggerStories from './tabs-trigger.stories';
+import * as TabsContentStories from './tabs-content.stories';
+
+<Meta of={TabsRootStories} />
+
+# Tabs
+
+A navigation component that organises content into separate, switchable panels.
+
+For the quick-start preset, see [TabsSimple](?path=/docs/composed-components-tabssimple--docs).
+
+<Primary />
+
+## Primitive Composition
+
+For full structural control, compose `TabsRoot`, `TabsList`, `TabsTrigger`, and `TabsContent` manually:
+
+```tsx
+import { TabsRoot, TabsList, TabsTrigger, TabsContent } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<TabsRoot defaultValue="tab1">
+			<TabsList variant="primary">
+				<TabsTrigger value="tab1">Tab 1</TabsTrigger>
+				<TabsTrigger value="tab2">Tab 2</TabsTrigger>
+			</TabsList>
+			<TabsContent value="tab1">Tab 1 content</TabsContent>
+			<TabsContent value="tab2">Tab 2 content</TabsContent>
+		</TabsRoot>
+	);
+}
+```
+
+> Note: Disabled tab tooltips and automatic lock-icon replacement for disabled states require the `Tabs` composed component. Primitive composition does not wrap `TabsTrigger` with `TooltipSimple`, so `disabledReason` has no effect.
+
+## TabsRoot Props
+
+<Controls of={TabsRootStories.Default} />
+
+## TabsList Props
+
+<Controls of={TabsListStories.Default} />
+
+## TabsTrigger Props
+
+<Controls of={TabsTriggerStories.Default} />
+
+## TabsContent Props
+
+<Controls of={TabsContentStories.Default} />

--- a/apps/docs/stories/tabs-root.stories.tsx
+++ b/apps/docs/stories/tabs-root.stories.tsx
@@ -3,7 +3,7 @@ import { TabsContent, TabsList, TabsRoot, TabsTrigger } from '@signozhq/ui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 
 const meta: Meta<typeof TabsRoot> = {
-	title: 'Primitive Components/Tabs/TabsRoot',
+	title: 'Primitive Components/Tabs/Tabs',
 	component: TabsRoot,
 	argTypes: {
 		defaultValue: {

--- a/apps/docs/stories/tabs.mdx
+++ b/apps/docs/stories/tabs.mdx
@@ -1,142 +1,165 @@
 import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
 import * as TabsStories from './tabs.stories';
-import * as TabsRootStories from './tabs-root.stories';
-import * as TabsListStories from './tabs-list.stories';
-import * as TabsTriggerStories from './tabs-trigger.stories';
-import * as TabsContentStories from './tabs-content.stories';
 
 <Meta of={TabsStories} />
 
-# Tabs
+# TabsSimple
 
-A flexible tabbed interface component with primary and secondary variants, supporting icons and disabled states.
+Preset that accepts an `items` array and renders a tabbed interface with primary and secondary variants, prefix/suffix icons, disabled states with tooltips, and optional tab bar extra content.
+
+For full primitive control, see [Tabs](?path=/docs/primitive-components-tabs-tabs--docs).
 
 ## How to use
 
-### Tabs (items-based API)
-
-Use the main `Tabs` component with an `items` array for the most common use case:
-
 ```tsx
 import { Tabs } from '@signozhq/ui';
-import { Settings, CircleAlert } from '@signozhq/icons';
+
+const items = [
+	{ key: 'overview', label: 'Overview', children: 'Overview content' },
+	{ key: 'analytics', label: 'Analytics', children: 'Analytics content' },
+	{ key: 'settings', label: 'Settings', children: 'Settings content' },
+];
 
 export default function MyComponent() {
-	const items = [
-		{
-			key: 'overview',
-			label: 'Overview',
-			children: 'Overview content',
-			prefixIcon: <Settings className="size-4" />,
-		},
-		{
-			key: 'issues',
-			label: 'Issues',
-			children: 'Issues content',
-			prefixIcon: <CircleAlert className="size-4" />,
-		},
-	];
-
 	return (
-		<Tabs
-			items={items}
-			variant="primary"
-			defaultValue="overview"
-		/>
+		<Tabs items={items} defaultValue="overview" />
 	);
 }
-```
-
-### Controlled state
-
-For controlled tabs, use `value` and `onChange`:
-
-```tsx
-import { Tabs } from '@signozhq/ui';
-
-export default function MyComponent() {
-	const [activeTab, setActiveTab] = React.useState('tab1');
-
-	return (
-		<Tabs
-			variant="secondary"
-			value={activeTab}
-			onChange={setActiveTab}
-			items={[
-				{ key: 'tab1', label: 'Overview', children: <div>Overview content</div> },
-				{ key: 'tab2', label: 'Details', children: <div>Details content</div> },
-			]}
-		/>
-	);
-}
-```
-
-### With icons and disabled tabs
-
-```tsx
-import { Tabs } from '@signozhq/ui';
-import { House, Lock } from '@signozhq/icons';
-
-<Tabs
-	items={[
-		{
-			key: 'home',
-			label: 'Home',
-			prefixIcon: <House />,
-			children: <div>Home</div>,
-		},
-		{
-			key: 'settings',
-			label: 'Settings',
-			disabled: true,
-			disabledReason: 'Coming soon',
-			children: <div>Settings</div>,
-		},
-	]}
-/>
 ```
 
 <Primary />
 
-## Tabs Props
+## Variants
 
-<Controls of={TabsStories.Default} />
-
-## Primitive composition
-
-For full control, use the low-level building blocks: `TabsRoot`, `TabsList`, `TabsTrigger`, and `TabsContent`.
+Switch between `primary` (default) and `secondary` styles with the `variant` prop:
 
 ```tsx
-import { TabsRoot, TabsList, TabsTrigger, TabsContent } from '@signozhq/ui';
+// Primary variant (default) — underline indicator with hover slider
+<Tabs items={items} variant="primary" defaultValue="overview" />
 
-export default function MyComponent() {
+// Secondary variant — pill-style tabs with a bottom border
+<Tabs items={items} variant="secondary" defaultValue="overview" />
+```
+
+## With icons
+
+Add `prefixIcon` or `suffixIcon` to tab items to display icons alongside the label:
+
+```tsx
+import { Settings, History } from '@signozhq/icons';
+
+<Tabs
+	items={[
+		{
+			key: 'settings',
+			label: 'Settings',
+			prefixIcon: <Settings className="size-4" />,
+			children: 'Settings content',
+		},
+		{
+			key: 'history',
+			label: 'History',
+			suffixIcon: <History className="size-4" />,
+			children: 'History content',
+		},
+	]}
+	defaultValue="settings"
+/>
+```
+
+## Disabled tabs
+
+Disabled tabs automatically display a lock icon (replacing any `prefixIcon`) and show a tooltip on hover. Use `disabledReason` to customise the tooltip message:
+
+```tsx
+<Tabs
+	items={[
+		{ key: 'active', label: 'Active', children: 'Active content' },
+		{
+			key: 'locked',
+			label: 'Issues',
+			disabled: true,
+			disabledReason: 'Feature is under maintenance',
+			children: 'Issues content',
+		},
+		{
+			key: 'beta',
+			label: 'Beta',
+			disabled: true,
+			children: 'Beta content',
+		},
+	]}
+	defaultValue="active"
+/>
+```
+
+## Tab bar extra content
+
+Render additional content to the left or right of the tab list with `tabBarLeftContent` and `tabBarRightContent`:
+
+```tsx
+import { Button, ButtonVariant, ButtonSize, ButtonColor } from '@signozhq/ui';
+import { Plus } from '@signozhq/icons';
+
+<Tabs
+	items={items}
+	defaultValue="overview"
+	tabBarRightContent={
+		<Button
+			variant={ButtonVariant.Outlined}
+			size={ButtonSize.SM}
+			color={ButtonColor.Secondary}
+			prefix={<Plus className="size-4" />}
+		>
+			Add view
+		</Button>
+	}
+/>
+```
+
+Combine both sides:
+
+```tsx
+<Tabs
+	items={items}
+	defaultValue="overview"
+	tabBarLeftContent={<span className="text-xs opacity-60">Service: frontend</span>}
+	tabBarRightContent={<Button>Configure</Button>}
+/>
+```
+
+## Alignment
+
+Control how the tab list positions itself within its container using the `alignment` prop (`left`, `center`, `right`):
+
+```tsx
+<Tabs items={items} alignment="center" defaultValue="overview" />
+<Tabs items={items} alignment="right" defaultValue="overview" />
+```
+
+Alignment works alongside `tabBarLeftContent` and `tabBarRightContent` — the tab list shifts between the extra content slots.
+
+## Controlled state
+
+Pass `value` and `onChange` to drive the active tab from external state:
+
+```tsx
+import { useState } from 'react';
+import { Tabs } from '@signozhq/ui';
+
+function MyComponent() {
+	const [activeTab, setActiveTab] = useState('overview');
+
 	return (
-		<TabsRoot defaultValue="tab1">
-			<TabsList variant="primary">
-				<TabsTrigger value="tab1">Tab 1</TabsTrigger>
-				<TabsTrigger value="tab2">Tab 2</TabsTrigger>
-			</TabsList>
-			<TabsContent value="tab1">Tab 1 content</TabsContent>
-			<TabsContent value="tab2">Tab 2 content</TabsContent>
-		</TabsRoot>
+		<Tabs
+			items={items}
+			value={activeTab}
+			onChange={setActiveTab}
+		/>
 	);
 }
 ```
 
-> Note: We do not recommend using primitive composition since the variant `primary` is not supported.
+## Props
 
-## TabsRoot Props
-
-<Controls of={TabsRootStories.Default} />
-
-## TabsList Props
-
-<Controls of={TabsListStories.Default} />
-
-## TabsTrigger Props
-
-<Controls of={TabsTriggerStories.Default} />
-
-## TabsContent Props
-
-<Controls of={TabsContentStories.Default} />
+<Controls of={TabsStories.Default} />

--- a/apps/docs/stories/tabs.stories.tsx
+++ b/apps/docs/stories/tabs.stories.tsx
@@ -28,7 +28,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import type * as React from 'react';
 
 const meta: Meta<typeof Tabs> = {
-	title: 'Composed Components/Tabs/TabsSimple',
+	title: 'Composed Components/TabsSimple',
 	component: Tabs,
 	argTypes: {
 		items: {
@@ -106,10 +106,26 @@ const meta: Meta<typeof Tabs> = {
 			description: 'Additional CSS classes to apply to the tabs root.',
 			table: { category: 'Styling', type: { summary: 'string' } },
 		},
+		tabBarLeftContent: {
+			control: false,
+			description: 'Content rendered to the left of the tab list, in the same horizontal row.',
+			table: { category: 'Content', type: { summary: 'React.ReactNode' } },
+		},
+		tabBarRightContent: {
+			control: false,
+			description: 'Content rendered to the right of the tab list, in the same horizontal row.',
+			table: { category: 'Content', type: { summary: 'React.ReactNode' } },
+		},
+		testId: {
+			control: 'text',
+			description: 'Test ID applied to the tabs root element.',
+			table: { category: 'Testing', type: { summary: 'string' } },
+		},
 	},
 	parameters: {
 		layout: 'fullscreen',
 	},
+	tags: ['autodocs'],
 };
 
 export default meta;


### PR DESCRIPTION
Closes #286

## Changes

- Added `tabs-root.mdx` — dedicated Storybook docs page for the Tabs primitives (`TabsRoot`, `TabsList`, `TabsTrigger`, `TabsContent`) with a full composition example, a note on `disabledReason` behaviour with primitives, and individual Props tables for each sub-component.
- Rewrote `tabs.mdx` to focus solely on the `TabsSimple` composed component. Added sections for Variants, With icons, Disabled tabs, Tab bar extra content, Alignment, and Controlled state. Added cross-link to the new Tabs primitive docs page.
- Changed `tabs.stories.tsx` title from `Composed Components/Tabs/TabsSimple` to `Composed Components/TabsSimple` — removes the extra nesting level in the sidebar. Added missing `tabBarLeftContent`, `tabBarRightContent`, and `testId` argTypes. Added `tags: ['autodocs']`.
- Changed `tabs-root.stories.tsx` title from `Primitive Components/Tabs/TabsRoot` to `Primitive Components/Tabs/Tabs` — aligns with the site-wide pattern where the primitive overview page uses the component family name (same as `Primitive Components/Breadcrumb/Breadcrumb`).
- Added missing `leftContent` and `rightContent` argTypes to `tabs-list.stories.tsx` so the TabsList Props table in the primitive docs is complete.

## Evidence


https://github.com/user-attachments/assets/673c7981-8033-4716-8a8d-b96fc3a0cfa7



## How to test

```
pnpm --filter docs dev
```

1. Open Storybook → **Composed Components > TabsSimple** — should show the focused docs page with variants, icons, disabled states, tab bar extra content, alignment, and controlled state sections. Cross-link at the top should read "For full primitive control, see [Tabs]" and navigate correctly.
2. Open **Primitive Components > Tabs > Tabs** — should show the new dedicated docs with full primitive composition example, the `disabledReason` note, and Props tables for `TabsRoot`, `TabsList`, `TabsTrigger`, and `TabsContent`.
3. Confirm `TabsSimple` is no longer nested under a "Tabs" sub-folder in the Composed Components section.
4. Confirm the TabsList Props table includes `leftContent` and `rightContent` entries.