### PR TITLE
docs(dialog): add dedicated mdx docs for AlertDialog, ConfirmDialog, and DialogWrapper

### DIFF
--- a/apps/docs/stories/alert-dialog.mdx
+++ b/apps/docs/stories/alert-dialog.mdx
@@ -1,0 +1,71 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as AlertDialogStories from './alert-dialog.stories';
+
+<Meta of={AlertDialogStories} />
+
+# AlertDialog
+
+A dialog preset for destructive or high-impact actions. Always blocks outside-click dismissal and hides the close button to ensure the user makes an explicit choice.
+
+Optionally renders a checkbox (e.g. "Don't ask me again") and accepts a custom `footer` with action buttons.
+
+For full primitive control, see [Dialog](?path=/docs/primitive-components-dialog--docs).
+
+## How to use
+
+```tsx
+import { useState } from 'react';
+import { AlertDialog, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	const [open, setOpen] = useState(false);
+	const [dontAskAgain, setDontAskAgain] = useState(false);
+
+	return (
+		<AlertDialog
+			open={open}
+			onOpenChange={setOpen}
+			title="Delete this step"
+			checkboxLabel="Do not ask me this again"
+			checkboxChecked={dontAskAgain}
+			onCheckboxChange={setDontAskAgain}
+			trigger={<Button>Delete</Button>}
+			footer={
+				<>
+					<Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+					<Button color="destructive" onClick={() => setOpen(false)}>Delete</Button>
+				</>
+			}
+		>
+			Deleting this step would stop further analytics using this step.
+		</AlertDialog>
+	);
+}
+```
+
+<Primary />
+
+## Without checkbox
+
+Omit `checkboxLabel` to render the alert dialog without the checkbox:
+
+```tsx
+<AlertDialog
+	open={open}
+	onOpenChange={setOpen}
+	title="Permanently delete"
+	trigger={<Button>Delete</Button>}
+	footer={
+		<>
+			<Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
+			<Button color="destructive" onClick={() => setOpen(false)}>Delete</Button>
+		</>
+	}
+>
+	This action cannot be undone.
+</AlertDialog>
+```
+
+## Props
+
+<Controls of={AlertDialogStories.Default} />

--- a/apps/docs/stories/alert-dialog.stories.tsx
+++ b/apps/docs/stories/alert-dialog.stories.tsx
@@ -4,7 +4,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import React from 'react';
 
 const meta: Meta<typeof AlertDialog> = {
-	title: 'Composed Components/Dialog/AlertDialog',
+	title: 'Composed Components/AlertDialog',
 	component: AlertDialog,
 	argTypes: {
 		open: {

--- a/apps/docs/stories/confirm-dialog-url.stories.tsx
+++ b/apps/docs/stories/confirm-dialog-url.stories.tsx
@@ -5,13 +5,12 @@ import { NuqsAdapter } from 'nuqs/adapters/react';
 import { confirmUrlArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof ConfirmDialogUrl> = {
-	title: 'Composed Components/Dialog/ConfirmDialogUrl',
+	title: 'Composed Components/ConfirmDialogUrl',
 	component: ConfirmDialogUrl,
 	argTypes: confirmUrlArgTypes,
 	parameters: {
 		layout: 'fullscreen',
 	},
-	tags: ['autodocs'],
 };
 
 export default meta;

--- a/apps/docs/stories/confirm-dialog.mdx
+++ b/apps/docs/stories/confirm-dialog.mdx
@@ -1,0 +1,120 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as ConfirmDialogStories from './confirm-dialog.stories';
+import * as ConfirmDialogUrlStories from './confirm-dialog-url.stories';
+
+<Meta of={ConfirmDialogStories} />
+
+# ConfirmDialog
+
+A dialog preset for confirm/cancel flows. Renders a title, optional description, and footer with configurable confirm and cancel buttons.
+
+For full primitive control, see [Dialog](?path=/docs/primitive-components-dialog--docs).
+
+## How to use
+
+```tsx
+import { useState } from 'react';
+import { ConfirmDialog, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<Button onClick={() => setOpen(true)}>Delete</Button>
+			<ConfirmDialog
+				open={open}
+				onOpenChange={setOpen}
+				title="Confirm action"
+				confirmText="Delete"
+				cancelText="Cancel"
+				confirmColor="destructive"
+				onConfirm={() => setOpen(false)}
+				onCancel={() => setOpen(false)}
+				width="narrow"
+			>
+				Are you sure? This action cannot be undone.
+			</ConfirmDialog>
+		</>
+	);
+}
+```
+
+<Primary />
+
+## Async confirm
+
+Pass an async `onConfirm` handler — the confirm button shows a loading state until the promise resolves. Return `true` to close the dialog, or `false` to keep it open:
+
+```tsx
+<ConfirmDialog
+	open={open}
+	onOpenChange={setOpen}
+	title="Delete record"
+	confirmText="Delete"
+	confirmColor="destructive"
+	onConfirm={async () => {
+		await deleteRecord();
+		return true;
+	}}
+	onCancel={() => setOpen(false)}
+>
+	This will permanently delete the record.
+</ConfirmDialog>
+```
+
+## Props
+
+<Controls of={ConfirmDialogStories.Default} />
+
+---
+
+## ConfirmDialogUrl
+
+Variant of `ConfirmDialog` that syncs the open state with a URL boolean query parameter via [nuqs](https://nuqs.dev/). Useful for shareable or bookmarkable confirmation states.
+
+### How to use
+
+Wrap your app (or page) in `NuqsAdapter` and use `useQueryState` to open the dialog by setting the URL param:
+
+```tsx
+import { ConfirmDialogUrl, Button } from '@signozhq/ui';
+import { useQueryState, parseAsBoolean } from 'nuqs';
+import { NuqsAdapter } from 'nuqs/adapters/react';
+
+function DeleteDialog() {
+	const [, setOpen] = useQueryState('dialog-delete-step', parseAsBoolean.withDefault(false));
+
+	return (
+		<>
+			<Button onClick={() => setOpen(true)}>Open confirm dialog (URL)</Button>
+			<ConfirmDialogUrl
+				urlKey="dialog-delete-step"
+				title="Delete from URL param"
+				confirmText="Delete"
+				cancelText="Cancel"
+				confirmColor="destructive"
+				onConfirm={async () => {
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					return true;
+				}}
+				width="narrow"
+			>
+				This confirm dialog is controlled via a URL query parameter using nuqs.
+			</ConfirmDialogUrl>
+		</>
+	);
+}
+
+export default function MyComponent() {
+	return (
+		<NuqsAdapter>
+			<DeleteDialog />
+		</NuqsAdapter>
+	);
+}
+```
+
+### Props
+
+<Controls of={ConfirmDialogUrlStories.Default} />

--- a/apps/docs/stories/confirm-dialog.stories.tsx
+++ b/apps/docs/stories/confirm-dialog.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { confirmArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof ConfirmDialog> = {
-	title: 'Composed Components/Dialog/ConfirmDialog',
+	title: 'Composed Components/ConfirmDialog',
 	component: ConfirmDialog,
 	argTypes: confirmArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog-wrapper.mdx
+++ b/apps/docs/stories/dialog-wrapper.mdx
@@ -1,0 +1,87 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as DialogWrapperStories from './dialog-wrapper.stories';
+
+<Meta of={DialogWrapperStories} />
+
+# DialogWrapper
+
+Preset that wraps `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, and an optional footer in a single component. Pass a `title`, optional `trigger`, and children.
+
+For full primitive control, see [Dialog](?path=/docs/primitive-components-dialog--docs).
+
+## How to use
+
+```tsx
+import { DialogWrapper, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<DialogWrapper
+			title="Edit Details"
+			trigger={<Button variant="solid">Open Dialog</Button>}
+		>
+			<p>Dialog content goes here.</p>
+		</DialogWrapper>
+	);
+}
+```
+
+<Primary />
+
+## Controlled state
+
+Pass `open` and `onOpenChange` to drive the open state externally. This also enables exit animations internally via `AnimatePresence`:
+
+```tsx
+import { useState } from 'react';
+import { DialogWrapper, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<DialogWrapper
+			open={open}
+			onOpenChange={setOpen}
+			title="Controlled Dialog"
+			trigger={<Button>Open</Button>}
+		>
+			<p>Dialog content goes here.</p>
+		</DialogWrapper>
+	);
+}
+```
+
+## Width variants
+
+Use `width` to control the width of the dialog surface. Options: `narrow`, `base` (default), `wide`, `extra-wide`:
+
+```tsx
+<DialogWrapper title="Wide dialog" width="wide" trigger={<Button>Open</Button>}>
+	<p>Wide dialog content.</p>
+</DialogWrapper>
+```
+
+## Without close button
+
+Set `showCloseButton={false}` to hide the default X button. Provide your own close action in the content or footer:
+
+```tsx
+import { DialogWrapper, DialogClose, Button } from '@signozhq/ui';
+
+<DialogWrapper
+	title="No close button"
+	showCloseButton={false}
+	trigger={<Button>Open</Button>}
+>
+	<div className="flex justify-end">
+		<DialogClose asChild>
+			<Button>Close</Button>
+		</DialogClose>
+	</div>
+</DialogWrapper>
+```
+
+## Props
+
+<Controls of={DialogWrapperStories.Default} />

--- a/apps/docs/stories/dialog-wrapper.stories.tsx
+++ b/apps/docs/stories/dialog-wrapper.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { wrapperArgTypes } from './shared/dialog-drawer-arg-types.js';
 
 const meta: Meta<typeof DialogWrapper> = {
-	title: 'Composed Components/Dialog/DialogWrapper',
+	title: 'Composed Components/DialogWrapper',
 	component: DialogWrapper,
 	argTypes: wrapperArgTypes,
 	parameters: {

--- a/apps/docs/stories/dialog.mdx
+++ b/apps/docs/stories/dialog.mdx
@@ -1,9 +1,5 @@
-import { Meta, Controls, Primary, Story } from '@storybook/addon-docs/blocks';
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
 import * as DialogStories from './dialog.stories';
-import * as DialogWrapperStories from './dialog-wrapper.stories';
-import * as ConfirmDialogStories from './confirm-dialog.stories';
-import * as ConfirmDialogUrlStories from './confirm-dialog-url.stories';
-import * as AlertDialogStories from './alert-dialog.stories';
 import * as DialogPrimitiveStories from './dialog-primitive.stories';
 import * as DialogTriggerStories from './dialog-trigger.stories';
 import * as DialogContentStories from './dialog-content.stories';
@@ -19,171 +15,13 @@ import * as DialogPortalStories from './dialog-portal.stories';
 
 # Dialog
 
-A modal dialog component for displaying content that requires user attention or interaction.
+Low-level primitives for building modal dialogs with full control over structure and behaviour.
+
+For ready-made presets, see [DialogWrapper](?path=/docs/composed-components-dialogwrapper--docs), [ConfirmDialog](?path=/docs/composed-components-confirmdialog--docs), or [AlertDialog](?path=/docs/composed-components-alertdialog--docs).
 
 ## How to use
 
-### DialogWrapper (preset)
-
-Use `DialogWrapper` for a simple dialog with title, optional trigger, and content. Pass `open` and `onOpenChange` for controlled mode with exit animations:
-
-```tsx
-import { DialogWrapper, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	const [open, setOpen] = React.useState(false);
-
-	return (
-		<DialogWrapper
-			open={open}
-			onOpenChange={setOpen}
-			title="Edit Details"
-			trigger={<Button variant="solid">Open Dialog</Button>}
-		>
-			<div className="flex flex-col gap-4">
-				<p>Dialog content goes here</p>
-				<div className="flex justify-end">
-					<Button variant="solid" color="primary" onClick={() => setOpen(false)}>
-						Save Changes
-					</Button>
-				</div>
-			</div>
-		</DialogWrapper>
-	);
-}
-```
-
-<Primary />
-
-## DialogWrapper Props
-
-<Controls of={DialogWrapperStories.Default} />
-
-## ConfirmDialog
-
-For confirm/cancel flows with a title, description, and footer actions:
-
-```tsx
-import { ConfirmDialog, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	const [open, setOpen] = useState(false);
-
-	return (
-		<>
-			<Button onClick={() => setOpen(true)}>Delete</Button>
-			<ConfirmDialog
-				open={open}
-				onOpenChange={setOpen}
-				title="Confirm action"
-				confirmText="Delete"
-				cancelText="Cancel"
-				confirmColor="destructive"
-				onConfirm={() => setOpen(false)}
-				onCancel={() => setOpen(false)}
-				width="narrow"
-			>
-				Are you sure? This action cannot be undone.
-			</ConfirmDialog>
-		</>
-	);
-}
-```
-
-## ConfirmDialog Props
-
-<Controls of={ConfirmDialogStories.Default} />
-
-## AlertDialog
-
-For destructive or high-impact actions, with optional checkbox (e.g. “Don’t ask again”) and custom footer:
-
-```tsx
-import { AlertDialog, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	const [open, setOpen] = useState(false);
-	const [dontAskAgain, setDontAskAgain] = useState(false);
-
-	return (
-		<AlertDialog
-			open={open}
-			onOpenChange={setOpen}
-			title="Delete this step"
-			checkboxLabel="Do not ask me this again"
-			checkboxChecked={dontAskAgain}
-			onCheckboxChange={setDontAskAgain}
-			trigger={<Button>Delete</Button>}
-			footer={
-				<>
-					<Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
-					<Button color="destructive" onClick={() => setOpen(false)}>Delete</Button>
-				</>
-			}
-		>
-			Deleting this step would stop further analytics using this step.
-		</AlertDialog>
-	);
-}
-```
-
-## AlertDialog Props
-
-<Controls of={AlertDialogStories.Default} />
-
-## ConfirmDialogUrl
-
-For confirm dialogs controlled via a URL query parameter:
-
-> This component requires the setup with [nuqs](https://nuqs.dev/).
-
-```tsx
-import { ConfirmDialogUrl, Button } from '@signozhq/ui';
-import { useQueryState, parseAsBoolean } from 'nuqs';
-
-export default function MyComponent() {
-    const [, setOpen] = useQueryState('dialog-delete-step', parseAsBoolean.withDefault(false));
-
-	return (
-		<>
-			<Button
-				variant="solid"
-				color="primary"
-				onClick={() => setOpen(true)}
-			>
-				Open confirm dialog (URL)
-			</Button>
-			<ConfirmDialogUrl
-				urlKey="dialog-delete-step"
-				title="Delete from URL param"
-				confirmText="Delete"
-				cancelText="Cancel"
-				confirmColor="destructive"
-				onConfirm={async () => {
-					// Simulate async work, this will change the button to loading state
-					await new Promise((resolve) => setTimeout(resolve, 300));
-					return true;
-				}}
-				width="narrow"
-			>
-				This confirm dialog is controlled via a URL query parameter using nuqs.
-			</ConfirmDialogUrl>
-		</>
-	);
-}
-```
-
-## ConfirmDialogUrl Props
-
-<Controls of={ConfirmDialogUrlStories.Default} />
-
-## Primitive composition
-
-For full control, use the low-level building blocks: `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, and `DialogClose`.
-
-### Exit animations
-
-To animate the dialog on close, wrap `DialogContent` in `AnimatePresence` and pass `forceMount` plus a stable `key`:
+Compose `Dialog`, `DialogTrigger`, `DialogContent`, `DialogHeader`, `DialogTitle`, `DialogDescription`, `DialogFooter`, and `DialogClose` directly:
 
 ```tsx
 import {
@@ -198,6 +36,7 @@ import {
 	Button,
 } from '@signozhq/ui';
 import { AnimatePresence } from 'motion/react';
+import { useState } from 'react';
 
 export default function MyComponent() {
 	const [open, setOpen] = useState(false);
@@ -213,9 +52,7 @@ export default function MyComponent() {
 						<DialogHeader>
 							<DialogTitle>Title</DialogTitle>
 						</DialogHeader>
-						<DialogDescription>
-							Description and body content.
-						</DialogDescription>
+						<DialogDescription>Description and body content.</DialogDescription>
 						<DialogFooter>
 							<Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
 							<DialogClose asChild>
@@ -230,7 +67,35 @@ export default function MyComponent() {
 }
 ```
 
-Without `AnimatePresence`, `forceMount`, and `key`, the dialog closes instantly. `DialogWrapper` uses this pattern internally when `open` and `onOpenChange` are provided.
+<Primary />
+
+## Exit animations
+
+Wrap `DialogContent` in `AnimatePresence` and pass `forceMount` plus a stable `key` to animate the dialog on close. Without these three, the dialog unmounts instantly with no exit animation.
+
+`DialogWrapper` uses this pattern internally when `open` and `onOpenChange` are provided.
+
+## Position variants
+
+`DialogContent` accepts a `position` prop to anchor the dialog surface to any edge of the viewport: `center` (default), `top`, `right`, `bottom`, `left`.
+
+```tsx
+<Dialog open={open} onOpenChange={setOpen}>
+	<DialogTrigger asChild>
+		<Button>Open right</Button>
+	</DialogTrigger>
+	<AnimatePresence>
+		{open && (
+			<DialogContent key="dialog-right" position="right" width="base" forceMount>
+				<DialogHeader>
+					<DialogTitle>Right panel</DialogTitle>
+				</DialogHeader>
+				<DialogDescription>Content slides in from the right.</DialogDescription>
+			</DialogContent>
+		)}
+	</AnimatePresence>
+</Dialog>
+```
 
 ## Dialog Props
 
@@ -271,4 +136,3 @@ Without `AnimatePresence`, `forceMount`, and `key`, the dialog closes instantly.
 ## DialogPortal Props
 
 <Controls of={DialogPortalStories.Default} />
-


### PR DESCRIPTION
Closes #287

## Summary

- Added `alert-dialog.mdx`, `confirm-dialog.mdx`, and `dialog-wrapper.mdx` — dedicated Storybook docs pages for each composed dialog preset
- `confirm-dialog.mdx` includes `ConfirmDialogUrl` as a sub-section (per issue requirement)
- `dialog.mdx` scoped to primitive components only; cross-links to all three preset docs at the top
- Moved composed stories out of the `Dialog/` Storybook sub-folder so each preset gets its own top-level entry with an autodocs-style page
- Removed `tags: ['autodocs']` from `confirm-dialog-url.stories.tsx` since it is now documented inside `confirm-dialog.mdx`

## Evidence


https://github.com/user-attachments/assets/3177553f-ca90-4765-a81e-56d327924fdf



## Test plan

- [x] Open Storybook and verify `AlertDialog`, `ConfirmDialog`, `DialogWrapper` each appear as top-level entries under Composed Components with their own Docs tab
- [x] Verify `ConfirmDialogUrl` appears as a section inside the ConfirmDialog docs page
- [x] Verify the Dialog primitives page links correctly to all three preset pages
- [x] Verify each preset docs page links back to the Dialog primitives page