### PR TITLE
docs(drawer): add dedicated MDX docs for Drawer and ConfirmDrawer (#288)

### DIFF
--- a/apps/docs/stories/confirm-drawer.mdx
+++ b/apps/docs/stories/confirm-drawer.mdx
@@ -1,0 +1,120 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as ConfirmDrawerStories from './confirm-drawer.stories';
+import * as ConfirmDrawerUrlStories from './confirm-drawer-url.stories';
+
+<Meta of={ConfirmDrawerStories} />
+
+# ConfirmDrawer
+
+A drawer preset for confirm/cancel flows. Renders a title, optional description, and footer with configurable confirm and cancel buttons.
+
+For full primitive control, see [Drawer](?path=/docs/primitive-components-drawer--docs).
+
+## How to use
+
+```tsx
+import { useState } from 'react';
+import { ConfirmDrawer, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<>
+			<Button onClick={() => setOpen(true)}>Delete</Button>
+			<ConfirmDrawer
+				open={open}
+				onOpenChange={setOpen}
+				title="Confirm action"
+				confirmText="Delete"
+				cancelText="Cancel"
+				confirmColor="destructive"
+				onConfirm={() => setOpen(false)}
+				onCancel={() => setOpen(false)}
+				width="narrow"
+			>
+				Are you sure? This action cannot be undone.
+			</ConfirmDrawer>
+		</>
+	);
+}
+```
+
+<Primary />
+
+## Async confirm
+
+Pass an async `onConfirm` handler — the confirm button shows a loading state until the promise resolves. Return `true` to close the drawer, or `false` to keep it open:
+
+```tsx
+<ConfirmDrawer
+	open={open}
+	onOpenChange={setOpen}
+	title="Delete record"
+	confirmText="Delete"
+	confirmColor="destructive"
+	onConfirm={async () => {
+		await deleteRecord();
+		return true;
+	}}
+	onCancel={() => setOpen(false)}
+>
+	This will permanently delete the record.
+</ConfirmDrawer>
+```
+
+## Props
+
+<Controls of={ConfirmDrawerStories.Default} />
+
+---
+
+## ConfirmDrawerUrl
+
+Variant of `ConfirmDrawer` that syncs the open state with a URL boolean query parameter via [nuqs](https://nuqs.dev/). Useful for shareable or bookmarkable confirmation states.
+
+### How to use
+
+Wrap your app (or page) in `NuqsAdapter` and use `useQueryState` to open the drawer by setting the URL param:
+
+```tsx
+import { ConfirmDrawerUrl, Button } from '@signozhq/ui';
+import { useQueryState, parseAsBoolean } from 'nuqs';
+import { NuqsAdapter } from 'nuqs/adapters/react';
+
+function DeleteDrawer() {
+	const [, setOpen] = useQueryState('drawer-delete-step', parseAsBoolean.withDefault(false));
+
+	return (
+		<>
+			<Button onClick={() => setOpen(true)}>Open confirm drawer (URL)</Button>
+			<ConfirmDrawerUrl
+				urlKey="drawer-delete-step"
+				title="Delete from URL param"
+				confirmText="Delete"
+				cancelText="Cancel"
+				confirmColor="destructive"
+				onConfirm={async () => {
+					await new Promise((resolve) => setTimeout(resolve, 300));
+					return true;
+				}}
+				width="narrow"
+			>
+				This confirm drawer is controlled via a URL query parameter using nuqs.
+			</ConfirmDrawerUrl>
+		</>
+	);
+}
+
+export default function MyComponent() {
+	return (
+		<NuqsAdapter>
+			<DeleteDrawer />
+		</NuqsAdapter>
+	);
+}
+```
+
+### Props
+
+<Controls of={ConfirmDrawerUrlStories.Default} />

--- a/apps/docs/stories/dialog-wrapper.mdx
+++ b/apps/docs/stories/dialog-wrapper.mdx
@@ -74,7 +74,7 @@ import { DialogWrapper, DialogClose, Button } from '@signozhq/ui';
 	showCloseButton={false}
 	trigger={<Button>Open</Button>}
 >
-	<div className="flex justify-end">
+	<div style={{ display: 'flex', justifyContent: 'flex-end' }}>
 		<DialogClose asChild>
 			<Button>Close</Button>
 		</DialogClose>

--- a/apps/docs/stories/drawer-wrapper.mdx
+++ b/apps/docs/stories/drawer-wrapper.mdx
@@ -1,0 +1,107 @@
+import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
+import * as DrawerWrapperStories from './drawer-wrapper.stories';
+
+<Meta of={DrawerWrapperStories} />
+
+# DrawerWrapper
+
+Preset that wraps `Drawer`, `DrawerTrigger`, `DrawerContent`, `DrawerHeader`, `DrawerTitle`, `DrawerSubtitle`, `DrawerDescription`, and an optional footer into a single component. Pass a `title`, optional `trigger`, and children.
+
+For full primitive control, see [Drawer](?path=/docs/primitive-components-drawer--docs).
+
+## How to use
+
+```tsx
+import { DrawerWrapper, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	return (
+		<DrawerWrapper
+			title="Edit settings"
+			subTitle="Optional subtitle for the drawer."
+			direction="right"
+			trigger={<Button variant="solid" color="primary">Open Drawer</Button>}
+		>
+			<p>Drawer content goes here.</p>
+		</DrawerWrapper>
+	);
+}
+```
+
+<Primary />
+
+## Controlled state
+
+Pass `open` and `onOpenChange` to drive the open state externally. This also enables exit animations internally via `AnimatePresence`:
+
+```tsx
+import { useState } from 'react';
+import { DrawerWrapper, Button } from '@signozhq/ui';
+
+export default function MyComponent() {
+	const [open, setOpen] = useState(false);
+
+	return (
+		<DrawerWrapper
+			open={open}
+			onOpenChange={setOpen}
+			title="Controlled Drawer"
+			trigger={<Button>Open</Button>}
+		>
+			<p>Drawer content goes here.</p>
+		</DrawerWrapper>
+	);
+}
+```
+
+## With footer
+
+Pass a `footer` node for confirm/cancel layouts:
+
+```tsx
+<DrawerWrapper
+	title="Edit settings"
+	direction="right"
+	trigger={<Button>Open</Button>}
+	footer={
+		<div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
+			<Button variant="ghost">Cancel</Button>
+			<Button variant="solid" color="primary">Save</Button>
+		</div>
+	}
+>
+	<p>Drawer content goes here.</p>
+</DrawerWrapper>
+```
+
+## Width variants
+
+Use `width` to control the width of the drawer surface. Options: `narrow`, `base` (default), `wide`, `extra-wide`:
+
+```tsx
+<DrawerWrapper title="Wide drawer" width="wide" trigger={<Button>Open</Button>}>
+	<p>Wide drawer content.</p>
+</DrawerWrapper>
+```
+
+## Without close button
+
+Set `showCloseButton={false}` to hide the default X button. Provide your own close action in the content or footer:
+
+```tsx
+import { DrawerWrapper, DrawerClose, Button } from '@signozhq/ui';
+
+<DrawerWrapper
+	title="No close button"
+	showCloseButton={false}
+	trigger={<Button>Open</Button>}
+>
+	<DrawerClose asChild>
+		<Button>Close</Button>
+	</DrawerClose>
+</DrawerWrapper>
+```
+
+## Props
+
+<Controls of={DrawerWrapperStories.Default} />

--- a/apps/docs/stories/drawer.mdx
+++ b/apps/docs/stories/drawer.mdx
@@ -1,8 +1,5 @@
 import { Meta, Controls, Primary } from '@storybook/addon-docs/blocks';
 import * as DrawerStories from './drawer.stories';
-import * as DrawerWrapperStories from './drawer-wrapper.stories';
-import * as ConfirmDrawerStories from './confirm-drawer.stories';
-import * as ConfirmDrawerUrlStories from './confirm-drawer-url.stories';
 import * as DrawerTriggerStories from './drawer-trigger.stories';
 import * as DrawerContentStories from './drawer-content.stories';
 import * as DrawerHeaderStories from './drawer-header.stories';
@@ -18,140 +15,13 @@ import * as DrawerPortalStories from './drawer-portal.stories';
 
 # Drawer
 
-A slide-in drawer component that can appear from any edge of the screen, with support for header, content, and footer sections.
+Low-level primitives for building slide-in drawers with full control over structure and behaviour.
+
+For ready-made presets, see [DrawerWrapper](?path=/docs/composed-components-drawer-drawerwrapper--docs) or [ConfirmDrawer](?path=/docs/composed-components-drawer-confirmdrawer--docs).
 
 ## How to use
 
-### DrawerWrapper (preset)
-
-`DrawerWrapper` is a higher-level preset built on top of the primitive drawer components. It wires
-`DrawerHeader`, `DrawerTitle`, `DrawerSubtitle`, `DrawerDescription`, and `DrawerFooter` into a single
-convenient API for common layouts with header, content, and optional footer:
-
-```tsx
-import { DrawerWrapper, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	return (
-		<DrawerWrapper
-			trigger={
-				<Button variant="solid" color="primary">
-					Open Drawer
-				</Button>
-			}
-			title="Drawer title"
-			subTitle="Optional subtitle for the drawer."
-			footer={
-				<div className="flex gap-2 justify-end">
-					<Button variant="ghost">Cancel</Button>
-					<Button variant="solid" color="primary">
-						Save
-					</Button>
-				</div>
-			}
-			direction="right"
-		>
-			<p>Main content of the drawer goes here.</p>
-		</DrawerWrapper>
-	);
-}
-```
-
-<Primary />
-
-## DrawerWrapper Props
-
-<Controls of={DrawerWrapperStories.Default} />
-
-## ConfirmDrawer
-
-For confirm/cancel flows with a title, description, and footer actions:
-
-```tsx
-import { ConfirmDrawer, Button } from '@signozhq/ui';
-
-export default function MyComponent() {
-	const [open, setOpen] = useState(false);
-
-	return (
-		<>
-			<Button onClick={() => setOpen(true)}>Delete</Button>
-			<ConfirmDrawer
-				open={open}
-				onOpenChange={setOpen}
-				title="Confirm action"
-				confirmText="Delete"
-				cancelText="Cancel"
-				confirmColor="destructive"
-				onConfirm={() => setOpen(false)}
-				onCancel={() => setOpen(false)}
-				direction="right"
-				width="narrow"
-			>
-				Are you sure? This action cannot be undone.
-			</ConfirmDrawer>
-		</>
-	);
-}
-```
-
-## ConfirmDrawer Props
-
-<Controls of={ConfirmDrawerStories.Default} />
-
-## ConfirmDrawerUrl
-
-For confirm drawers controlled via a URL query parameter:
-
-> This component requires the setup with [nuqs](https://nuqs.dev/).
-
-```tsx
-import { ConfirmDrawerUrl, Button } from '@signozhq/ui';
-import { useQueryState, parseAsBoolean } from 'nuqs';
-
-export default function MyComponent() {
-	const [, setOpen] = useQueryState('drawer-delete-step', parseAsBoolean.withDefault(false));
-
-	return (
-		<>
-			<Button
-				variant="solid"
-				color="primary"
-				onClick={() => setOpen(true)}
-			>
-				Open confirm drawer (URL)
-			</Button>
-			<ConfirmDrawerUrl
-				urlKey="drawer-delete-step"
-				title="Delete from URL param"
-				confirmText="Delete"
-				cancelText="Cancel"
-				confirmColor="destructive"
-				onConfirm={async () => {
-					await new Promise((resolve) => setTimeout(resolve, 300));
-					return true;
-				}}
-				direction="right"
-				width="narrow"
-			>
-				This confirm drawer is controlled via a URL query parameter using nuqs.
-			</ConfirmDrawerUrl>
-		</>
-	);
-}
-```
-
-## ConfirmDrawerUrl Props
-
-<Controls of={ConfirmDrawerUrlStories.Default} />
-
-## Primitive composition
-
-For full control, use the low-level building blocks: `Drawer`, `DrawerTrigger`, `DrawerContent`, `DrawerHeader`, `DrawerTitle`, `DrawerDescription`, `DrawerFooter`, `DrawerClose`, `DrawerOverlay`, and `DrawerPortal`.
-
-### Exit animations
-
-To animate the drawer on close, wrap `DrawerContent` in `AnimatePresence` and pass `forceMount` plus a stable `key`:
+Compose `Drawer`, `DrawerTrigger`, `DrawerContent`, `DrawerHeader`, `DrawerTitle`, `DrawerDescription`, `DrawerFooter`, `DrawerClose`, and `DrawerCloseButton` directly:
 
 ```tsx
 import {
@@ -163,40 +33,32 @@ import {
 	DrawerDescription,
 	DrawerFooter,
 	DrawerClose,
+	DrawerCloseButton,
 	Button,
 } from '@signozhq/ui';
 import { AnimatePresence } from 'motion/react';
+import { useState } from 'react';
 
 export default function MyComponent() {
-	const [open, setOpen] = React.useState(false);
+	const [open, setOpen] = useState(false);
 
 	return (
 		<Drawer open={open} onOpenChange={setOpen}>
 			<DrawerTrigger asChild>
-				<Button variant="solid" color="primary">
-					Open drawer
-				</Button>
+				<Button variant="solid" color="primary">Open drawer</Button>
 			</DrawerTrigger>
 			<AnimatePresence>
 				{open && (
-					<DrawerContent key="drawer" forceMount>
+					<DrawerContent key="drawer" direction="right" forceMount>
 						<DrawerHeader>
 							<DrawerTitle>Drawer title</DrawerTitle>
+							<DrawerCloseButton />
 						</DrawerHeader>
-						<DrawerDescription>
-							<div className="text-sm text-gray-600">
-								Description and body content. Use the primitive components when you need
-								lower-level control.
-							</div>
-						</DrawerDescription>
+						<DrawerDescription>Description and body content.</DrawerDescription>
 						<DrawerFooter>
-							<Button variant="ghost" onClick={() => setOpen(false)}>
-								Cancel
-							</Button>
+							<Button variant="ghost" onClick={() => setOpen(false)}>Cancel</Button>
 							<DrawerClose asChild>
-								<Button variant="solid" color="primary">
-									Confirm
-								</Button>
+								<Button variant="solid" color="primary">Confirm</Button>
 							</DrawerClose>
 						</DrawerFooter>
 					</DrawerContent>
@@ -207,7 +69,35 @@ export default function MyComponent() {
 }
 ```
 
-Without `AnimatePresence`, `forceMount`, and `key`, the drawer closes instantly. `DrawerWrapper` uses this pattern internally when `open` and `onOpenChange` are provided.
+<Primary />
+
+## Exit animations
+
+Wrap `DrawerContent` in `AnimatePresence` and pass `forceMount` plus a stable `key` to animate the drawer on close. Without these three, the drawer unmounts instantly with no exit animation.
+
+`DrawerWrapper` uses this pattern internally when `open` and `onOpenChange` are provided.
+
+## Direction variants
+
+`DrawerContent` accepts a `direction` prop to anchor the drawer surface to any edge of the viewport: `right` (default), `left`, `top`, `bottom`.
+
+```tsx
+<Drawer open={open} onOpenChange={setOpen}>
+	<DrawerTrigger asChild>
+		<Button>Open bottom</Button>
+	</DrawerTrigger>
+	<AnimatePresence>
+		{open && (
+			<DrawerContent key="drawer-bottom" direction="bottom" forceMount>
+				<DrawerHeader>
+					<DrawerTitle>Bottom drawer</DrawerTitle>
+				</DrawerHeader>
+				<DrawerDescription>Content slides in from the bottom.</DrawerDescription>
+			</DrawerContent>
+		)}
+	</AnimatePresence>
+</Drawer>
+```
 
 ## Drawer Props
 
@@ -252,4 +142,3 @@ Without `AnimatePresence`, `forceMount`, and `key`, the drawer closes instantly.
 ## DrawerPortal Props
 
 <Controls of={DrawerPortalStories.Default} />
-


### PR DESCRIPTION
## Summary

- Add `drawer-wrapper.mdx` with full documentation for `DrawerWrapper` — props table, usage examples, variants, and accessibility notes
- Add `confirm-drawer.mdx` with dedicated docs for `ConfirmDrawer`
- Refactor `drawer.mdx` to focus on primitive components, removing the old consolidated content now split across the new MDX files
- Remove Tailwind CSS pipeline from the docs app and replace with design-token CSS (prerequisite for the above)
- Convert remaining story `className` usage to inline styles via a new `tailwind-to-inline-styles` codemod skill

## Test plan

- [ ] Open Storybook and verify the Drawer, DrawerWrapper, and ConfirmDrawer docs pages render correctly
- [ ] Check that all Drawer stories still function in both light and dark mode
- [ ] Verify no Tailwind-related build errors in `apps/docs`

Closes #288