### PR TITLE
ci(chromatic): update workflow to reduce snapshot count

### DIFF
--- a/.github/workflows/chromatic-main.yml
+++ b/.github/workflows/chromatic-main.yml
@@ -1,0 +1,50 @@
+name: "Chromatic (main)"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types: [closed]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    # Only on merge, and only if the merged PR carried the `run-visual-testing` label.
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'run-visual-testing')
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js 24.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+
+      - name: Install Dependencies and Build
+        run: |
+          pnpm install
+          pnpm build
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          # pull_request context detects the PR head branch; force main so the
+          # build is treated as a baseline and autoAcceptChanges applies.
+          branchName: main
+          autoAcceptChanges: main
+          onlyChanged: true

--- a/.github/workflows/chromatic-pr.yml
+++ b/.github/workflows/chromatic-pr.yml
@@ -1,16 +1,14 @@
-name: "Chromatic"
+name: "Chromatic (PR)"
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   chromatic:
@@ -21,6 +19,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -39,5 +38,6 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@latest
         with:
-          # ⚠️ Make sure to configure a `CHROMATIC_PROJECT_TOKEN` repository secret
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          onlyChanged: true
+          skip: ${{ !contains(github.event.pull_request.labels.*.name, 'run-visual-testing') }}

--- a/VISUAL_TESTING.md
+++ b/VISUAL_TESTING.md
@@ -1,0 +1,114 @@
+# Visual Testing
+
+This repo uses [Chromatic](https://www.chromatic.com/) to catch unintended visual
+changes in components. Chromatic builds the Storybook in `apps/docs`, renders every
+story into snapshots, and diffs them against an accepted baseline. When a snapshot
+changes, the build is flagged for human review.
+
+## TL;DR
+
+- Visual tests do **not** run automatically on every PR.
+- Add the **`run-visual-testing`** label to a PR to run Chromatic against it.
+- Review the diffs in the Chromatic UI (link is posted on the PR check).
+- On merge, a second workflow re-runs Chromatic and **auto-accepts** the merged
+  changes as the new `main` baseline.
+
+## How it works
+
+There are two workflows plus a shared config. The split exists so PR builds compare
+against `main`, and merged builds update the `main` baseline.
+
+### 1. PR builds — `.github/workflows/chromatic-pr.yml`
+
+Runs on pull requests targeting `main` (`opened`, `synchronize`, `reopened`,
+`labeled`).
+
+Key behaviour:
+
+- **`skip` unless labeled.** The job is skipped unless the PR carries the
+  `run-visual-testing` label:
+  ```yaml
+  skip: ${{ !contains(github.event.pull_request.labels.*.name, 'run-visual-testing') }}
+  ```
+  Adding the label (the `labeled` trigger) kicks off a build immediately. This is the
+  main cost lever — no label, no snapshots.
+- **`cancel-in-progress: true`.** Pushing new commits cancels the in-flight build so
+  only the latest commit is snapshotted.
+- **`onlyChanged: true`** (TurboSnap). Only stories affected by the changed files are
+  snapshotted, instead of the whole Storybook.
+- Checks out the PR **head SHA** so the diff reflects exactly what's in the PR.
+
+The build appears as a check on the PR with a link to the Chromatic UI, where you
+accept or deny each visual change.
+
+### 2. Baseline update on merge — `.github/workflows/chromatic-main.yml`
+
+Runs when a PR to `main` is **closed**, but only does work when:
+
+```yaml
+github.event.pull_request.merged == true &&
+contains(github.event.pull_request.labels.*.name, 'run-visual-testing')
+```
+
+i.e. the PR was actually merged **and** it had the `run-visual-testing` label.
+
+Key behaviour:
+
+- Checks out the **merge commit SHA**.
+- Forces the build to be treated as `main`:
+  ```yaml
+  branchName: main
+  autoAcceptChanges: main
+  ```
+  This re-baselines `main`: the changes you reviewed and merged are auto-accepted as
+  the new reference, so the next PR doesn't re-flag them.
+- **`cancel-in-progress: false`** — baseline builds must not be cancelled.
+- **`onlyChanged: true`** as well.
+
+### Why two workflows?
+
+- A PR build needs to diff against the current `main` baseline → run on the PR head.
+- A merge build needs to *become* the new `main` baseline → run on the merge commit
+  with `branchName: main` + `autoAcceptChanges: main`.
+
+Doing both in one workflow would either re-baseline on every PR (changes never get
+reviewed) or never update the baseline (every PR re-flags already-accepted changes).
+
+## Configuration — `apps/docs/chromatic.config.json`
+
+Shared by both workflows and the local `chromatic` script.
+
+| Key | Purpose |
+|-----|---------|
+| `projectId` | Chromatic project this Storybook belongs to. |
+| `storybookBaseDir` | Repo-relative root of the Storybook (`./apps/docs`) — anchors TurboSnap's change detection. |
+| `storybookConfigDir` | Storybook config dir (`./apps/docs/.storybook`). |
+| `storybookBuildDir` | Prebuilt static Storybook output (`./storybook-static`). |
+| `onlyChanged` | Enables TurboSnap by default. |
+| `zip` | Uploads the build as a zip (faster for large Storybooks). |
+| `externals` | Non-source assets (fonts, css, favicons) that, when changed, should be handled by TurboSnap correctly rather than silently skipped. |
+
+`projectToken` is **not** in this file — it comes from the `CHROMATIC_PROJECT_TOKEN`
+repository secret (CI) or your environment (local).
+
+## Component-level tests (separate from Chromatic)
+
+Storybook also runs interaction/render tests via Vitest in a real browser
+(Playwright/Chromium):
+
+```bash
+cd apps/docs
+pnpm test-storybook   # vitest --project=storybook
+```
+
+These verify behaviour/rendering and run independently of Chromatic's pixel diffing.
+
+## Typical workflow
+
+1. Open a PR with component or story changes.
+2. If the change is visual, add the **`run-visual-testing`** label → PR build runs.
+3. Open the Chromatic link on the PR check; accept or deny each diff.
+4. Get the PR reviewed and merge.
+5. The merge build auto-accepts the merged changes as the new `main` baseline.
+
+If a PR has no visual impact, leave the label off — no snapshots are spent.

--- a/apps/docs/chromatic.config.json
+++ b/apps/docs/chromatic.config.json
@@ -1,6 +1,26 @@
 {
 	"onlyChanged": true,
 	"projectId": "Project:67150c0b65fc0b0f718b1a58",
-	"storybookBaseDir": "apps/docs",
-	"zip": true
+	"storybookBaseDir": "./apps/docs",
+	"zip": true,
+	"$schema": "https://www.chromatic.com/config-file.schema.json",
+	"storybookConfigDir": "./apps/docs/.storybook",
+	"storybookBuildDir": "./storybook-static",
+	"externals": [
+		"storybook-static/favicon-wrapper.svg",
+		"storybook-static/favicon.svg",
+		"storybook-static/nunito-sans-bold-italic.woff2",
+		"storybook-static/nunito-sans-bold.woff2",
+		"storybook-static/nunito-sans-italic.woff2",
+		"storybook-static/nunito-sans-regular.woff2",
+		"storybook-static/sb-common-assets/favicon-wrapper.svg",
+		"storybook-static/sb-common-assets/favicon.svg",
+		"storybook-static/sb-common-assets/nunito-sans-bold-italic.woff2",
+		"storybook-static/sb-common-assets/nunito-sans-bold.woff2",
+		"storybook-static/sb-common-assets/nunito-sans-italic.woff2",
+		"storybook-static/sb-common-assets/nunito-sans-regular.woff2",
+		"storybook-static/assets/iframe-BEHBz_83.css",
+		"blue-demo.css",
+		"index.css"
+	]
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -9,7 +9,7 @@
 		"preview-storybook": "serve storybook-static",
 		"build-storybook": "storybook build -o storybook-static",
 		"clean": "rm -rf .turbo && rm -rf node_modules",
-		"chromatic": "pnpm dlx chromatic --exit-zero-on-changes ",
+		"chromatic": "pnpm dlx chromatic --exit-zero-on-changes  --config-file 'chromatic.config.json'",
 		"test": "vitest",
 		"test-storybook": "vitest --project=storybook"
 	},


### PR DESCRIPTION
Follow-ups of https://app.notion.com/p/signoz/Visual-Testing-Chromatic-380fcc6bcd19800698b9e2bd58618947

Limitations:
- This runs via `pull_request`, meaning the external contributors will not have access to have visual testing.

Closes #303