### PR TITLE
chore: update tmp package to version 0.2.7 and add version constraint…

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
 			"sass": "1.78.0",
 			"eslint-config-prettier": "9.1.0",
 			"eslint-import-resolver-typescript": "3.10.0",
-			"ajv@<6.14.0": "^6.14.2"
+			"ajv@<6.14.0": "^6.14.2",
+			"tmp@<0.2.6": ">=0.2.6"
 		},
 		"packageExtensions": {
 			"vite-plugin-lib-inject-css": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,7 @@ overrides:
   eslint-config-prettier: 9.1.0
   eslint-import-resolver-typescript: 3.10.0
   ajv@<6.14.0: ^6.14.2
+  tmp@<0.2.6: '>=0.2.6'
 
 packageExtensionsChecksum: sha256-pbAhz4S9ckQT1t7W1ZdC6RssHIxKgH+QX6pai/FBocY=
 
@@ -6340,8 +6341,8 @@ packages:
     resolution: {integrity: sha512-1r6vQTTt1rUiJkI5vX7KG8PR342Ru/5Oh13kEQP2SMbRSZpOey9SrBe27IDxkoWulx8ShWu4K6C0BkctP8Z1bQ==}
     hasBin: true
 
-  tmp@0.2.4:
-    resolution: {integrity: sha512-UdiSoX6ypifLmrfQ/XfiawN6hkjSBpCjhKxxZcWlUUmoXLaCKQU0bx4HF/tdDK2uzRuchf1txGvrWBzYREssoQ==}
+  tmp@0.2.7:
+    resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
 
   to-regex-range@5.0.1:
@@ -10556,7 +10557,7 @@ snapshots:
     dependencies:
       chardet: 0.7.0
       iconv-lite: 0.4.24
-      tmp: 0.2.4
+      tmp: 0.2.7
 
   fast-deep-equal@3.1.3: {}
 
@@ -13205,7 +13206,7 @@ snapshots:
     dependencies:
       tldts-core: 7.0.24
 
-  tmp@0.2.4: {}
+  tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:


### PR DESCRIPTION
… in package.json


 tmp@0.2.4 was pulled in transitively (inquirer → @inquirer/prompts →
  @inquirer/editor → external-editor → tmp) and is vulnerable to path
  traversal via unsanitized prefix/postfix (CVE-2026-44705,
  GHSA-ph9p-34f9-6g65, high).

  external-editor pins tmp to an old range, so it can't be bumped
  directly. Added a pnpm override forcing tmp to the patched >=0.2.6
  (resolves to 0.2.7). Dev-only dependency chain; docs build verified
  passing.

  Resolves Dependabot alert #107.