### PR TITLE
ci(chromatic): try fix the issue with turbosnap not being enabled/computed

### DIFF
--- a/.github/workflows/chromatic-main.yml
+++ b/.github/workflows/chromatic-main.yml
@@ -43,10 +43,16 @@ jobs:
 
       - name: Run Chromatic
         uses: chromaui/action@latest
+        # The action reads the commit and branch from the pull_request context,
+        # which points at the PR head. Squash merges leave that commit
+        # unreachable from main, so the baseline lands under a SHA later runs
+        # can't resolve and TurboSnap falls back to an ancient build. Report the
+        # squash commit that actually landed on main, on main, instead.
+        env:
+          CHROMATIC_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          CHROMATIC_BRANCH: main
+          CHROMATIC_SLUG: ${{ github.repository }}
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          # pull_request context detects the PR head branch; force main so the
-          # build is treated as a baseline and autoAcceptChanges applies.
-          branchName: main
           autoAcceptChanges: main
           onlyChanged: true

--- a/VISUAL_TESTING.md
+++ b/VISUAL_TESTING.md
@@ -43,11 +43,16 @@ snapshots:
 - **PR build** (`.github/workflows/chromatic-pr.yml`) runs on the PR head and **diffs
   against** the current `main` baseline, so you can review what changed.
 - **Merge build** (`.github/workflows/chromatic-main.yml`) runs on the merge commit and
-  **becomes** the new `main` baseline (`branchName: main` + `autoAcceptChanges: main`),
-  so the next PR doesn't re-flag changes you already accepted.
+  **becomes** the new `main` baseline (`CHROMATIC_BRANCH: main` + `autoAcceptChanges:
+  main`), so the next PR doesn't re-flag changes you already accepted.
 
 Doing both in one workflow would either re-baseline on every PR (changes never get
 reviewed) or never update the baseline (every PR re-flags already-accepted changes).
+
+The merge build also sets `CHROMATIC_SHA` to the merge commit. Left alone, the action
+reports the PR head instead, which a squash merge leaves unreachable from `main` — the
+baseline is then filed under a commit later runs can't resolve, and TurboSnap silently
+falls back to the oldest build with a reachable commit and re-snapshots everything.
 
 The merge build only runs when the PR was actually **merged** and carries
 `update-visual-testing` — a PR closed without merging, or one that never ran Chromatic,


### PR DESCRIPTION
Not sure if it's a bug on chromatic or here, but this should help chromatic correctly identify the commit hashes from previous builds where it was not resolving the commit (and the snapshots stored) and causing the entire snapshot to be recomputed again, wasting quota.

- https://github.com/SigNoz/components/actions/runs/30835767140/job/91760434740?pr=344
- https://github.com/SigNoz/components/actions/runs/30836325442/job/91762278251#step:6:19